### PR TITLE
Make glb-redirect tests more resilient & reduce re-use

### DIFF
--- a/src/glb-redirect/tests/glb_test_utils.py
+++ b/src/glb-redirect/tests/glb_test_utils.py
@@ -1,0 +1,22 @@
+from scapy.all import sniff, send, conf, L3RawSocket6
+
+class GLBTestHelpers(object):
+	def _sendrecv6(self, pkt, **kwargs):
+		s = L3RawSocket6()
+		send(pkt)
+		ret = sniff(opened_socket=s, timeout=1, **kwargs)
+		s.close()
+		if len(ret) == 0:
+			assert False, "Expected to receive a response packet, but none received."
+		print "Received packet:", repr(ret[0])
+		return ret[0]
+
+	def _sendrecv4(self, pkt, **kwargs):
+		s = conf.L3socket(**kwargs)
+		s.send(pkt)
+		ret = sniff(opened_socket=s, timeout=1, **kwargs)
+		s.close()
+		if len(ret) == 0:
+			assert False, "Expected to receive a response packet, but none received."
+		print "Received packet:", repr(ret[0])
+		return ret[0]

--- a/src/glb-redirect/tests/test_glb_redirect_v4_on_v4.py
+++ b/src/glb-redirect/tests/test_glb_redirect_v4_on_v4.py
@@ -1,20 +1,14 @@
 from nose.tools import assert_equals
 from scapy.all import IP, UDP, TCP, ICMP, sniff, send, conf
 from glb_scapy import GLBGUEChainedRouting, GLBGUE
+from glb_test_utils import GLBTestHelpers
 import random
 
-class TestGLBRedirectModuleV4OnV4():
+class TestGLBRedirectModuleV4OnV4(GLBTestHelpers):
 	PROXY_HOST = '192.168.50.10'
 	ALT_HOST = '192.168.50.11'
 	SELF_HOST = '192.168.50.5'
 	VIP = '10.10.10.10'
-
-	def _sendrecv(self, pkt, **kwargs):
-		s = conf.L3socket(**kwargs)
-		s.send(pkt)
-		ret = sniff(opened_socket=s, timeout=1, **kwargs)
-		s.close()
-		return ret[0]
 
 	def test_00_icmp_accepted(self):
 		for dst in [self.PROXY_HOST, self.ALT_HOST]:
@@ -26,7 +20,7 @@ class TestGLBRedirectModuleV4OnV4():
 				ICMP(type=8, code=0) # echo request
 
 			# expect a ICMP echo response back from self.PROXY_HOST (decapsulated)
-			resp_ip = self._sendrecv(pkt, filter='host {} and icmp'.format(dst))
+			resp_ip = self._sendrecv4(pkt, filter='host {} and icmp'.format(dst))
 			print repr(resp_ip)
 			assert isinstance(resp_ip, IP)
 			assert_equals(resp_ip.src, dst)
@@ -47,7 +41,7 @@ class TestGLBRedirectModuleV4OnV4():
 			TCP(sport=123, dport=22, flags='S')
 
 		# expect a SYN-ACK back from self.PROXY_HOST (decapsulated)
-		resp_ip = self._sendrecv(pkt, filter='host {} and port 22'.format(self.PROXY_HOST))
+		resp_ip = self._sendrecv4(pkt, filter='host {} and port 22'.format(self.PROXY_HOST))
 		assert isinstance(resp_ip, IP)
 		assert_equals(resp_ip.src, self.PROXY_HOST)
 		assert_equals(resp_ip.dst, self.SELF_HOST)
@@ -68,7 +62,7 @@ class TestGLBRedirectModuleV4OnV4():
 
 		# expect the packet to arrive back to us as a FOU packet since nobody knew about the connection
 		# should arrive from the last host in the chain that wasn't us.
-		resp_ip = self._sendrecv(pkt, filter='host {} and udp and port 19523'.format(self.ALT_HOST))
+		resp_ip = self._sendrecv4(pkt, filter='host {} and udp and port 19523'.format(self.ALT_HOST))
 		assert isinstance(resp_ip, IP)
 		assert_equals(resp_ip.src, self.ALT_HOST) # outer FOU will come from penultimate hop
 		assert_equals(resp_ip.dst, self.SELF_HOST)
@@ -112,7 +106,7 @@ class TestGLBRedirectModuleV4OnV4():
 			TCP(sport=eph_port, dport=22, flags='S', seq=1234)
 
 		# retrieve the SYN-ACK
-		resp_ip = self._sendrecv(syn, filter='host {} and port 22'.format(self.VIP))
+		resp_ip = self._sendrecv4(syn, filter='host {} and port 22'.format(self.VIP))
 		assert isinstance(resp_ip, IP)
 		assert_equals(resp_ip.src, self.VIP)
 		assert_equals(resp_ip.dst, self.SELF_HOST)
@@ -135,7 +129,7 @@ class TestGLBRedirectModuleV4OnV4():
 			TCP(sport=eph_port, dport=22, flags='A', seq=syn_ack.ack, ack=syn_ack.seq + 1)
 
 		# ensure we get a PSH from the host, since SSH should send us the banner
-		resp_ip = self._sendrecv(ack, filter='host {} and port 22'.format(self.VIP))
+		resp_ip = self._sendrecv4(ack, filter='host {} and port 22'.format(self.VIP))
 		assert isinstance(resp_ip, IP)
 		assert_equals(resp_ip.src, self.VIP)
 		assert_equals(resp_ip.dst, self.SELF_HOST)

--- a/src/glb-redirect/tests/test_glb_redirect_v6_on_v4.py
+++ b/src/glb-redirect/tests/test_glb_redirect_v6_on_v4.py
@@ -1,9 +1,10 @@
 from nose.tools import assert_equals
 from scapy.all import IP, IPv6, UDP, TCP, ICMPv6EchoRequest, ICMPv6EchoReply, sniff, send, conf, L3RawSocket6
 from glb_scapy import GLBGUEChainedRouting, GLBGUE
+from glb_test_utils import GLBTestHelpers
 import random
 
-class TestGLBRedirectModuleV6OnV4():
+class TestGLBRedirectModuleV6OnV4(GLBTestHelpers):
 	PROXY_HOST = '192.168.50.10'
 	ALT_HOST = '192.168.50.11'
 	SELF_HOST = '192.168.50.5'
@@ -16,20 +17,6 @@ class TestGLBRedirectModuleV6OnV4():
 		'192.168.50.11': 'fd33:75c6:d3f2:7e9f::11',
 	}
 
-	def _sendrecv(self, pkt, **kwargs):
-		s = L3RawSocket6(**kwargs)
-		send(pkt)
-		ret = sniff(opened_socket=s, timeout=1, **kwargs)
-		s.close()
-		return ret[0]
-
-	def _sendrecv4(self, pkt, **kwargs):
-		s = conf.L3socket(**kwargs)
-		send(pkt)
-		ret = sniff(opened_socket=s, timeout=1, **kwargs)
-		s.close()
-		return ret[0]
-
 	def test_00_icmp_accepted(self):
 		for dst in [self.PROXY_HOST, self.ALT_HOST]:
 			pkt = \
@@ -40,8 +27,8 @@ class TestGLBRedirectModuleV6OnV4():
 				ICMPv6EchoRequest()
 			print repr(pkt)
 			# expect a ICMP echo response back from self.PROXY_HOST (decapsulated)
-			resp_ip = self._sendrecv(pkt, filter='ip6 host {} and icmp && ip6[40] == 129'.format(self.V4_TO_V6[dst]))
-			print repr(resp_ip)
+			resp_ip = self._sendrecv6(pkt, lfilter=lambda p: isinstance(p, IPv6) and isinstance(p.payload, ICMPv6EchoReply))
+
 			assert isinstance(resp_ip, IPv6)
 			assert_equals(resp_ip.src, self.V4_TO_V6[dst])
 			assert_equals(resp_ip.dst, self.SELF_HOST_V6)
@@ -59,7 +46,7 @@ class TestGLBRedirectModuleV6OnV4():
 			TCP(sport=123, dport=22, flags='S')
 
 		# expect a SYN-ACK back from self.PROXY_HOST (decapsulated)
-		resp_ip = self._sendrecv(pkt, filter='host {} and port 22'.format(self.V4_TO_V6[self.PROXY_HOST]))
+		resp_ip = self._sendrecv6(pkt, filter='host {} and port 22'.format(self.V4_TO_V6[self.PROXY_HOST]))
 		assert isinstance(resp_ip, IPv6)
 		assert_equals(resp_ip.src, self.V4_TO_V6[self.PROXY_HOST])
 		assert_equals(resp_ip.dst, self.SELF_HOST_V6)
@@ -80,7 +67,7 @@ class TestGLBRedirectModuleV6OnV4():
 
 		# expect the packet to arrive back to us as a FOU packet since nobody knew about the connection
 		# should arrive from the last host in the chain that wasn't us.
-		resp_ip = self._sendrecv4(pkt, filter='host {} and udp and port 19523'.format(self.ALT_HOST))
+		resp_ip = self._sendrecv4(pkt, filter='src host {} and udp and port 19523'.format(self.ALT_HOST))
 		assert isinstance(resp_ip, IP)
 		assert_equals(resp_ip.src, self.ALT_HOST) # outer FOU will come from penultimate hop
 		assert_equals(resp_ip.dst, self.SELF_HOST)
@@ -124,7 +111,7 @@ class TestGLBRedirectModuleV6OnV4():
 			TCP(sport=eph_port, dport=22, flags='S', seq=1234)
 
 		# retrieve the SYN-ACK
-		resp_ip = self._sendrecv(syn, filter='ip6 host {} and port 22'.format(self.VIP))
+		resp_ip = self._sendrecv6(syn, filter='ip6 host {} and port 22'.format(self.VIP))
 		assert isinstance(resp_ip, IPv6)
 		assert_equals(resp_ip.src, self.VIP)
 		assert_equals(resp_ip.dst, self.SELF_HOST_V6)
@@ -147,7 +134,7 @@ class TestGLBRedirectModuleV6OnV4():
 			TCP(sport=eph_port, dport=22, flags='A', seq=syn_ack.ack, ack=syn_ack.seq + 1)
 
 		# ensure we get a PSH from the host, since SSH should send us the banner
-		resp_ip = self._sendrecv(ack, filter='ip6 host {} and port 22'.format(self.VIP))
+		resp_ip = self._sendrecv6(ack, filter='ip6 host {} and port 22'.format(self.VIP))
 		assert isinstance(resp_ip, IPv6)
 		assert_equals(resp_ip.src, self.VIP)
 		assert_equals(resp_ip.dst, self.SELF_HOST_V6)


### PR DESCRIPTION
This PR fixes a few issues I found using the glb-redirect tests - from the resilience side it adds more specific packet filters in a couple of places and moves one filter to Python so it actually works (since scapy seems to have issues with complex filters, and just ignores them). Other than that, just some simple refactors to get shared test functions named consistently and in a parent class.