### PR TITLE
Remove workaround for Ubuntu Precise kernel builds.

### DIFF
--- a/src/glb-redirect/libxt_GLBREDIRECT.c
+++ b/src/glb-redirect/libxt_GLBREDIRECT.c
@@ -22,10 +22,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-// hacks for precise, because the system linux/asm includes don't match the trusty kernel
-#define _ASM_X86_POSIX_TYPES_64_H
-#include "asm-generic/posix_types.h"
-
 #include <xtables.h>
 #include "ipt_glbredirect.h"
 


### PR DESCRIPTION
This workaround was added due to build errors on Ubuntu Precise many years ago, but since Precise is EOL and glb-director doesn't intend to support it, it makes sense to remove it.

Fixes https://github.com/github/glb-director/issues/32