### PR TITLE
glb-healthcheck: Install glide and run `glide install` before building.

### DIFF
--- a/script/Dockerfile.stretch
+++ b/script/Dockerfile.stretch
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y build-essential dpdk dpdk-dev wget pkg-
 RUN apt-get update && apt-get install -y iptables-dev dkms debhelper libxtables-dev
 
 # golang
-RUN apt-get update && apt-get install -y golang
+RUN apt-get update && apt-get install -y golang golang-glide
 
 # fpm for packaging
 RUN apt-get update && apt-get install -y ruby ruby-dev rubygems build-essential

--- a/src/glb-healthcheck/script/cibuild
+++ b/src/glb-healthcheck/script/cibuild
@@ -41,6 +41,7 @@ mkdir -p .gopath/src/github.com/github
 ln -s `pwd`/../../ .gopath/src/github.com/github/glb-director
 export GOPATH=`pwd`/.gopath
 cd $GOPATH/src/github.com/github/glb-director/src/glb-healthcheck
+glide install
 go build
 
 fpm -f -s dir -t deb \


### PR DESCRIPTION
Fixes https://github.com/github/glb-director/issues/33, which reported build errors due to missing `vendor`ed packages. This PR adds `glide`, and then installs the packages we have configured, during `cibuild`.