### PR TITLE
Refactor packet parsing and flow hash calculation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ src/glb-redirect/glb-redirect-iptables-dkms-mkdeb
 build
 .DS_Store
 *.pyc
+*.mk
+*.cmd
+*.mod
+*.ko
+*.mod.c
+*.symvers
+*.order

--- a/src/glb-director/cli/Makefile
+++ b/src/glb-director/cli/Makefile
@@ -35,7 +35,6 @@ CHECK_SRCS = config_check.c \
 	../glb_fwd_config.c \
 	../bind_classifier.c \
 	../glb_director_config.c \
-	../glb_encap.c \
 	../siphash24.c \
 	../shared_opt.c
 

--- a/src/glb-director/cli/pcap_mode.c
+++ b/src/glb-director/cli/pcap_mode.c
@@ -134,13 +134,16 @@ int main(int argc, char **argv)
 
 		fp = fopen(packet_filename, "rb");
 
-		ret = fread(buffer, sizeof(buffer), 1, fp);
+		ret = fread(buffer, 1, sizeof(buffer), fp);
 
-		if (ret != 0) {
+		if (ret <= 0) {
 			glb_log_error_and_exit("failed to read packet file");
 		}
 
-		ret = glb_encapsulate_packet_pcap(config_ctx, buffer, 0);
+		pcap_packet pkt;
+		pkt.data = buffer;
+		pkt.len = ret;
+		ret = glb_encapsulate_packet_pcap(config_ctx, &pkt, 0);
 
 		if (ret != 0) {
 			glb_log_error_and_exit("packet encap failed!");

--- a/src/glb-director/glb_encap.h
+++ b/src/glb-director/glb_encap.h
@@ -31,26 +31,90 @@
  */
 
 #include <rte_ether.h>
+#include <rte_ip.h>
+
+#define IPV6_ADDR_SIZE 16
 
 struct glb_fwd_config_ctx;
 struct glb_fwd_config_content_table;
 
-typedef struct {
-	uint8_t hop_count;
-	uint32_t via_i;
-	uint32_t alt_i;
-	uint16_t flow_hash;
-	uint16_t ip_total_length;
-	uint64_t pkt_hash;
-	uint8_t gue_ipproto;
-} primary_secondary;
+struct icmpv6_hdr {
+	uint8_t type, code;
+	uint16_t checksum;
+} __attribute__((__packed__));
 
-int get_primary_secondary(struct glb_fwd_config_ctx *ctx, unsigned int table_id,
-			  struct ether_hdr *eth_hdr, primary_secondary *p_s);
+struct icmpv6_too_big_hdr {
+	uint32_t mtu;
+} __attribute__((__packed__));
+
+struct l4_ports_hdr {
+	uint16_t src_port;
+	uint16_t dst_port;
+} __attribute__((__packed__));
+
+/* Incoming packets can either be:
+ *   Ethernet / IP(v4/v6) / TCP|UDP / ...
+ *   Ethernet / IP(v4/v6) / ICMP / IP(v4/v6) / TCP|UDP ...
+ *
+ * We take the latter as the worst case.
+ * IPv6 header is longer than IPv4, so we account for that.
+ * We only read the src/dst port of the TCP/UDP header.
+ */
+#define MAX_PARSED_HEADER_SIZE ( \
+	sizeof(struct ether_hdr) + \
+	sizeof(struct ipv6_hdr) + \
+	sizeof(struct icmpv6_hdr) + sizeof(struct icmpv6_too_big_hdr) + \
+	sizeof(struct ipv6_hdr) + \
+	sizeof(struct l4_ports_hdr) \
+)
+
+#define MAX_HOPS 4
+
+typedef struct {
+	// aiding simple header extraction by maintaining state
+	uint8_t linearisation_space[MAX_PARSED_HEADER_SIZE];
+	uint32_t linearisation_space_offset;
+	void *packet_data;
+	uint32_t offset;
+
+	// extracted fields
+	uint16_t ether_type;
+
+	uint16_t ip_total_length;
+
+	union {
+		uint32_t ipv4;
+		uint8_t ipv6[IPV6_ADDR_SIZE];
+	} src_addr;
+
+	union {
+		uint32_t ipv4;
+		uint8_t ipv6[IPV6_ADDR_SIZE];
+	} dst_addr;
+
+	uint16_t src_port;
+	uint16_t dst_port;
+
+	// a hint used to spread flows across different RX queues via UDP source port.
+	uint16_t flow_hash_hint;
+
+	// mapped based on IPv4/IPv6
+	uint8_t gue_ipproto;
+
+	// calculated hops
+	uint8_t hop_count;
+	uint32_t ipv4_hops[MAX_HOPS];
+	
+	uint64_t pkt_hash;
+} glb_route_context;
+
+const void *encap_packet_data_read(void *packet_data, uint32_t off, uint32_t len, void *buf);
+
+int glb_calculate_packet_route(struct glb_fwd_config_ctx *ctx, unsigned int table_id,
+			  void *packet_data, glb_route_context *route_context);
 
 int glb_encapsulate_packet(struct ether_hdr *eth_hdr,
-			   struct ether_hdr orig_eth_hdr,
-			   primary_secondary *p_s);
+			   glb_route_context *route_context);
 
 struct glb_gue_hdr {
 	uint8_t version_control_hlen;
@@ -64,13 +128,4 @@ struct glb_gue_hdr {
 	uint8_t hop_count;
 
 	uint32_t hops[];
-} __attribute__((__packed__));;
-
-struct icmpv6_hdr {
-	uint8_t type, code;
-	uint16_t checksum;
-} __attribute__((__packed__));
-
-struct icmpv6_too_big_hdr {
-	uint32_t mtu;
 } __attribute__((__packed__));

--- a/src/glb-director/glb_encap_pcap.h
+++ b/src/glb-director/glb_encap_pcap.h
@@ -37,8 +37,13 @@ typedef struct {
 	struct glb_fwd_config_ctx *ctx;
 } configuration;
 
+typedef struct {
+	u_char *data;
+	size_t len;
+} pcap_packet;
+
 void glb_pcap_handler(configuration args[], const struct pcap_pkthdr *pkthdr,
 		      const u_char *pkt);
 
-int glb_encapsulate_packet_pcap(struct glb_fwd_config_ctx *ctx, u_char *pkt,
+int glb_encapsulate_packet_pcap(struct glb_fwd_config_ctx *ctx, pcap_packet *pkt,
 				unsigned int table_id);


### PR DESCRIPTION
This PR refactors the parsing of packets and subsequent retrieval of fields for flow hashing to be more isolated and resilient, in preparation for allowing customisation of the fields used in flow hashing. More specifically:
 * Parsing is changed from assuming a non-segmented packet, to `rte_pktmbuf_read` which supports linearising packet data if required.
   * The `linearisation_space` used here automates / hides away the implementation detail of requiring space for `rte_pktmbuf_read` to linearise segmented packets.
 * Field extraction and hashing are split apart, in preparation for the fields used in hashing being varied based on configuration.
   * The change from primary/secondary to route_context with next hops also prepares for allowing a variable sized list of next hops. The implementation detail of the first hop being used as the `dst_addr` is left to the encapsulation function, leaving the routing code to simply list the hops in order.
 * Components of the parsing code are made more defensive: even where ACL matchers guarantee that a packet has certain fields and is of a certain length, these boundaries are checked again during parsing.

The hashing itself has explicitly been left untouched to leave this as a pure refactor (no functional change), and will be adjusted in a follow up PR.