### PR TITLE
glb-redirect: support path MTU discovery

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -127,7 +127,6 @@ Vagrant.configure("2") do |config|
       v.vm.provision "shell", inline: <<-SHELL
         DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
         echo "hello world from #{name} via GLB" >/var/www/html/index.html
-        dd if=/dev/zero of=/var/www/html/test.bin bs=1000 count=1
       SHELL
 
       v.vm.provision "shell", run: "always", inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -127,6 +127,7 @@ Vagrant.configure("2") do |config|
       v.vm.provision "shell", inline: <<-SHELL
         DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
         echo "hello world from #{name} via GLB" >/var/www/html/index.html
+        dd if=/dev/zero of=/var/www/html/test.bin bs=1000 count=1
       SHELL
 
       v.vm.provision "shell", run: "always", inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -142,6 +142,11 @@ Vagrant.configure("2") do |config|
         ip addr add #{ipv6_addr} dev eth1 || true
 
         ip route add 192.168.40.0/24 via 192.168.50.2 dev eth1 || true
+        
+        cp /vagrant/script/helpers/test-snoop.service /etc/systemd/system/test-snoop.service
+        systemctl daemon-reload
+        systemctl enable test-snoop.service
+        systemctl restart test-snoop.service
       SHELL
     end
   end

--- a/script/helpers/test-snoop.py
+++ b/script/helpers/test-snoop.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+
+import SocketServer
+from scapy.all import *
+import struct, sys
+from scapy.all import L3RawSocket
+
+PORT = 9999
+
+class SnoopHandler(SocketServer.BaseRequestHandler):
+	def forward_packet(self, packet):
+		print('Forwarding packet: {}'.format(repr(packet)))
+		sys.stdout.flush()
+		raw_data = str(packet)
+		try:
+			self.request.sendall(struct.pack('!I', len(raw_data)))
+			self.request.sendall(raw_data)
+		except IOError:
+			print('IOError, continuing')
+			sys.stdout.flush()
+			return False # probably broken pipe
+		return True
+
+	def handle(self):
+		print('handling new client')
+		sys.stdout.flush()
+		s = L3RawSocket(iface='tunl0')
+		self.request.sendall('SYNC') # let the other side know we're ready (listening)
+		while True:
+			pkt = s.recv()
+			if isinstance(pkt, IP) and isinstance(pkt.payload, TCP):
+				if pkt.dport == PORT or pkt.sport == PORT: continue # don't talk about ourselves
+			if not self.forward_packet(pkt):
+				break
+
+class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
+    pass
+
+if __name__ == "__main__":
+	HOST, PORT = "0.0.0.0", PORT
+	server = ThreadedTCPServer((HOST, PORT), SnoopHandler)
+	server.serve_forever()

--- a/script/helpers/test-snoop.service
+++ b/script/helpers/test-snoop.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Test Snoop Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/vagrant/script/helpers/test-snoop.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/src/glb-redirect/tests/glb_test_remote_snoop.py
+++ b/src/glb-redirect/tests/glb_test_remote_snoop.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2018 GitHub.
+#
+# This file is part of the `glb-redirect` test suite.
+#
+# This file is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this project.  If not, see <https://www.gnu.org/licenses/>.
+
+from scapy.data import ETH_P_IP, ETH_P_IPV6
+from scapy.all import Ether
+import socket, time, struct
+
+class RemoteSnoop(object):
+	def __init__(self, remote_host, remote_port=9999, remote_type=ETH_P_IP, remote_iface='tunl0', debug=False):
+		self.debug = debug
+		self.remote_host = remote_host
+		# connect now so we start receiving our packets
+		self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		self.s.connect((remote_host, remote_port))
+
+		# send the ethertype and interface we expect
+		# (2 byte ethertype, 4 byte iface len, <iface data>)
+		raw_iface = remote_iface.encode('ascii')
+		self.s.sendall(struct.pack('!HI', remote_type, len(raw_iface)))
+		self.s.sendall(raw_iface)
+
+		# receive some bytes, so we know we're in sync and listening on the remote end
+		assert self.s.recv(4) == 'SYNC'
+
+	def recv(self, recv_filter, timeout=10):
+		self.s.settimeout(timeout)
+		start = time.time()
+		while time.time() < start + timeout:
+			pkt_len_raw = self.s.recv(4)
+			pkt_len, = struct.unpack('!I', pkt_len_raw)
+			pkt_raw = self.s.recv(pkt_len)
+
+			# we don't actually want Ether header, it's just a stub so we know the protocol.
+			# this means we can be lazy and Scapy do all the encoding/decoding work.
+			pkt_ether = Ether(pkt_raw)
+			pkt = pkt_ether.payload
+
+			if self.debug: print("got packet from {}: {}".format(self.remote_host, repr(pkt)))
+			if recv_filter(pkt):
+				if self.debug: print(" -> match!")
+				return pkt
+			else:
+				if self.debug: print(" -> not a match.")
+		return None

--- a/src/glb-redirect/tests/test_glb_redirect_v4_on_v4.py
+++ b/src/glb-redirect/tests/test_glb_redirect_v4_on_v4.py
@@ -19,36 +19,9 @@ from nose.tools import assert_equals, assert_true
 from scapy.all import IP, UDP, TCP, ICMP, sniff, send, conf
 from glb_scapy import GLBGUEChainedRouting, GLBGUE
 from glb_test_utils import GLBTestHelpers
+from glb_test_remote_snoop import RemoteSnoop
+from scapy.data import ETH_P_IP
 import random
-
-
-import socket, time, struct
-class RemoteSnoop(object):
-	def __init__(self, remote_host, remote_port=9999):
-		self.remote_host = remote_host
-		# connect now so we start receiving our packets
-		self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-		self.s.connect((remote_host, remote_port))
-		# receive some bytes, so we know we're in sync and listening on the remote end
-		assert self.s.recv(4) == 'SYNC'
-
-	def recv(self, recv_filter, timeout=10):
-		self.s.settimeout(timeout)
-		start = time.time()
-		while time.time() < start + timeout:
-			# TODO: we don't actually timeout here, need to break out of here as well
-			pkt_len_raw = self.s.recv(4)
-			pkt_len, = struct.unpack('!I', pkt_len_raw)
-			pkt_raw = self.s.recv(pkt_len)
-			pkt = IP(pkt_raw)
-			print("got packet from {}: {}".format(self.remote_host, repr(pkt)))
-			if recv_filter(pkt):
-				print(" -> match!")
-				return pkt
-			else:
-				print(" -> not a match.")
-		return None
-
 
 class TestGLBRedirectModuleV4OnV4(GLBTestHelpers):
 	PROXY_HOST = '192.168.50.10'
@@ -194,20 +167,19 @@ class TestGLBRedirectModuleV4OnV4(GLBTestHelpers):
 
 		# send a Packet Too Big message via PROXY from ROUTER, which
 		# should end up on the alt host
+		# note that we end on SELF_HOST so it doesn't 'default accept' it
 		pkt = \
 			IP(dst=self.PROXY_HOST) / \
 			UDP(sport=12345, dport=19523) / \
-			GLBGUE(private_data=GLBGUEChainedRouting(hops=[self.ALT_HOST, self.PROXY_HOST])) / \
+			GLBGUE(private_data=GLBGUEChainedRouting(hops=[self.ALT_HOST, self.SELF_HOST])) / \
 			IP(src=self.ROUTER, dst=self.VIP) / \
 			ICMP(type=3, code=4, nexthopmtu=800) / \
 			IP(src=self.VIP, dst=self.SELF_HOST) / \
 			TCP(sport=80, dport=eph_port, seq=ack, ack=seq)
 
-		alt_host_stream = RemoteSnoop(self.ALT_HOST)
+		alt_host_stream = RemoteSnoop(self.ALT_HOST, remote_iface='tunl0', remote_type=ETH_P_IP)
 		send(pkt)
 		rem_ip = alt_host_stream.recv(lambda pkt: pkt.src == self.ROUTER)
-
-		print("got: {}".format(repr(rem_ip)))
 
 		# ensure the remote host (ALT_HOST) received the inner packet through the first (failed) hop
 		assert isinstance(rem_ip, IP)
@@ -225,32 +197,11 @@ class TestGLBRedirectModuleV4OnV4(GLBTestHelpers):
 		assert_equals(rem_ipip.sport, 80)
 		assert_equals(rem_ipip.dport, eph_port)
 
-		# http_req = "GET /test.bin HTTP/1.0\r\n\r\n"
-
-		# req = \
-		# 	IP(dst=self.ALT_HOST) / \
-		# 	UDP(sport=12345, dport=19523) / \
-		# 	GLBGUE(private_data=GLBGUEChainedRouting(hops=[])) / \
-		# 	IP(src=self.SELF_HOST, dst=self.VIP) / \
-		# 	TCP(sport=eph_port, dport=80, flags='PA', seq=seq, ack=ack) / \
-		# 	http_req
-
-		# seq += len(http_req)
-
-		# print("sending request")
-		# resp = self._sendrecvmany4(req, count=3, lfilter=self._match_tuple(self.VIP, self.SELF_HOST, 80, eph_port))
-
-		# self._reset_conn(eph_port, 80, seq)
-
-		# assert_equals(resp[0].payload.flags, 'A')
-		# # TODO: Strange flags=RA packet
-		# assert_equals(resp[2].payload.flags, 'FPA')
-		# assert_true(len(resp[2].payload) > 800)
-
-
 	def _establish_conn(self, dport):
 		seq_no = random.randint(0, 2**32-1)
 		eph_port = random.randint(30000, 60000)
+
+		self._reset_conn(eph_port, dport, seq_no)
 
 		# create connection to the VIP on the alt host, which will accept the SYN
 		syn = \

--- a/src/glb-redirect/tests/test_glb_redirect_v4_on_v4.py
+++ b/src/glb-redirect/tests/test_glb_redirect_v4_on_v4.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this project.  If not, see <https://www.gnu.org/licenses/>.
 
-from nose.tools import assert_equals
+from nose.tools import assert_equals, assert_true
 from scapy.all import IP, UDP, TCP, ICMP, sniff, send, conf
 from glb_scapy import GLBGUEChainedRouting, GLBGUE
 from glb_test_utils import GLBTestHelpers
@@ -26,6 +26,7 @@ class TestGLBRedirectModuleV4OnV4(GLBTestHelpers):
 	ALT_HOST = '192.168.50.11'
 	SELF_HOST = '192.168.50.5'
 	VIP = '10.10.10.10'
+	ROUTER = '192.168.50.2'
 
 	def test_00_icmp_accepted(self):
 		for dst in [self.PROXY_HOST, self.ALT_HOST]:
@@ -47,7 +48,7 @@ class TestGLBRedirectModuleV4OnV4(GLBTestHelpers):
 			assert isinstance(resp_icmp, ICMP)
 			assert_equals(resp_icmp.type, 0) # echo reply
 			assert_equals(resp_icmp.code, 0)
-		
+
 
 	def test_01_syn_accepted(self):
 		pkt = \
@@ -68,7 +69,7 @@ class TestGLBRedirectModuleV4OnV4(GLBTestHelpers):
 		assert_equals(resp_tcp.sport, 22)
 		assert_equals(resp_tcp.dport, 123)
 		assert_equals(resp_tcp.flags, 'SA')
-	
+
 	def test_02_unknown_redirected_through_chain(self):
 		pkt = \
 			IP(dst=self.PROXY_HOST) / \
@@ -101,7 +102,7 @@ class TestGLBRedirectModuleV4OnV4(GLBTestHelpers):
 		assert isinstance(resp_inner_tcp, TCP)
 		assert_equals(resp_inner_tcp.sport, 9999)
 		assert_equals(resp_inner_tcp.dport, 22)
-	
+
 	def test_03_accepted_on_secondary_chain_host(self):
 		eph_port = random.randint(30000, 60000)
 
@@ -156,3 +157,80 @@ class TestGLBRedirectModuleV4OnV4(GLBTestHelpers):
 		assert_equals(resp_tcp.sport, 22)
 		assert_equals(resp_tcp.dport, eph_port)
 		assert_equals(resp_tcp.flags, 'PA')
+
+	def test_04_icmp_packet_too_big(self):
+		# Establish full connection, since ICMP is handled differently for
+		# sockets which haven't completed the full 3-way handshake (aka TCP_NEW_SYN_RECV).
+		(eph_port, seq, ack) = self._establish_conn(dport=80)
+
+		# send a Packet Too Big message via PROXY from ROUTER, which
+		# should end up on the alt host
+		pkt = \
+			IP(dst=self.PROXY_HOST) / \
+			UDP(sport=12345, dport=19523) / \
+			GLBGUE(private_data=GLBGUEChainedRouting(hops=[self.ALT_HOST, self.PROXY_HOST])) / \
+			IP(src=self.ROUTER, dst=self.VIP) / \
+			ICMP(type=3, code=4, nexthopmtu=800) / \
+			IP(src=self.VIP, dst=self.SELF_HOST) / \
+			TCP(sport=80, dport=eph_port, seq=ack, ack=seq)
+		send(pkt)
+
+		http_req = "GET /test.bin HTTP/1.0\r\n\r\n"
+
+		req = \
+			IP(dst=self.ALT_HOST) / \
+			UDP(sport=12345, dport=19523) / \
+			GLBGUE(private_data=GLBGUEChainedRouting(hops=[])) / \
+			IP(src=self.SELF_HOST, dst=self.VIP) / \
+			TCP(sport=eph_port, dport=80, flags='PA', seq=seq, ack=ack) / \
+			http_req
+
+		seq += len(http_req)
+
+		print("sending request")
+		resp = self._sendrecvmany4(req, count=3, lfilter=self._match_tuple(self.VIP, self.SELF_HOST, 80, eph_port))
+
+		self._reset_conn(eph_port, 80, seq)
+
+		assert_equals(resp[0].payload.flags, 'A')
+		# TODO: Strange flags=RA packet
+		assert_equals(resp[2].payload.flags, 'FPA')
+		assert_true(len(resp[2].payload) > 800)
+
+
+	def _establish_conn(self, dport):
+		seq_no = random.randint(0, 2**32-1)
+		eph_port = random.randint(30000, 60000)
+
+		# create connection to the VIP on the alt host, which will accept the SYN
+		syn = \
+			IP(dst=self.ALT_HOST) / \
+			UDP(sport=12345, dport=19523) / \
+			GLBGUE(private_data=GLBGUEChainedRouting(hops=[])) / \
+			IP(src=self.SELF_HOST, dst=self.VIP) / \
+			TCP(sport=eph_port, dport=dport, flags='S', seq=seq_no)
+
+		# retrieve the SYN-ACK
+		syn_ack = self._sendrecv4(syn, lfilter=self._match_tuple(self.VIP, self.SELF_HOST, dport, eph_port))
+
+		seq_no = syn_ack.ack
+		ack_no = syn_ack.seq+1
+
+		ack = \
+			IP(dst=self.ALT_HOST) / \
+			UDP(sport=12345, dport=19523) / \
+			GLBGUE(private_data=GLBGUEChainedRouting(hops=[])) / \
+			IP(src=self.SELF_HOST, dst=self.VIP) / \
+			TCP(sport=eph_port, dport=dport, flags='A', seq=seq_no, ack=ack_no)
+		send(ack)
+
+		return (eph_port, seq_no, ack_no)
+
+	def _reset_conn(self, sport, dport, seq):
+		rst = \
+			IP(dst=self.ALT_HOST) / \
+			UDP(sport=12345, dport=19523) / \
+			GLBGUE(private_data=GLBGUEChainedRouting(hops=[])) / \
+			IP(src=self.SELF_HOST, dst=self.VIP) / \
+			TCP(sport=sport, dport=dport, flags='R', seq=seq)
+		send(rst)

--- a/src/glb-redirect/tests/test_glb_redirect_v6_on_v4.py
+++ b/src/glb-redirect/tests/test_glb_redirect_v6_on_v4.py
@@ -19,6 +19,8 @@ from nose.tools import assert_equals
 from scapy.all import IP, IPv6, UDP, TCP, ICMPv6EchoRequest, ICMPv6EchoReply, ICMPv6PacketTooBig, sniff, send, conf, L3RawSocket6
 from glb_scapy import GLBGUEChainedRouting, GLBGUE
 from glb_test_utils import GLBTestHelpers
+from glb_test_remote_snoop import RemoteSnoop
+from scapy.data import ETH_P_IPV6
 import random
 
 class TestGLBRedirectModuleV6OnV4(GLBTestHelpers):
@@ -28,6 +30,7 @@ class TestGLBRedirectModuleV6OnV4(GLBTestHelpers):
 
 	SELF_HOST_V6 = 'fd33:75c6:d3f2:7e9f::5'
 	VIP = 'fd2c:394c:33a3:26bf::1'
+	ROUTER = 'fd33:75c6:d3f2:7e9f::2'
 
 	V4_TO_V6 = {
 		'192.168.50.10': 'fd33:75c6:d3f2:7e9f::10',
@@ -163,16 +166,46 @@ class TestGLBRedirectModuleV6OnV4(GLBTestHelpers):
 		assert_equals(resp_tcp.flags, 'PA')
 
 	def test_04_icmp_packet_too_big(self):
+		# Establish full connection, since ICMP is handled differently for
+		# sockets which haven't completed the full 3-way handshake (aka TCP_NEW_SYN_RECV).
+		(eph_port, seq, ack) = self._establish_conn(dport=80)
+
+		# send a Packet Too Big message via PROXY from ROUTER, which
+		# should end up on the alt host
+		# note that we end on SELF_HOST so it doesn't 'default accept' it
+		pkt = \
+			IP(dst=self.PROXY_HOST) / \
+			UDP(sport=12345, dport=19523) / \
+			GLBGUE(private_data=GLBGUEChainedRouting(hops=[self.ALT_HOST, self.SELF_HOST])) / \
+			IPv6(src=self.ROUTER, dst=self.VIP) / \
+			ICMPv6PacketTooBig(mtu=1400) / \
+			IPv6(src=self.VIP, dst=self.SELF_HOST_V6) / \
+			TCP(sport=80, dport=eph_port)
+		
+		alt_host_stream = RemoteSnoop(self.ALT_HOST, remote_iface='sit0', remote_type=ETH_P_IPV6)
+		send(pkt)
+		rem_ip = alt_host_stream.recv(lambda pkt: pkt.src == self.ROUTER)
+
+		# ensure the remote host (ALT_HOST) received the inner packet through the first (failed) hop
+		assert isinstance(rem_ip, IPv6)
+		assert_equals(rem_ip.src, self.ROUTER)
+		assert_equals(rem_ip.dst, self.VIP)
+		rem_icmp = rem_ip.payload
+		assert isinstance(rem_icmp, ICMPv6PacketTooBig)
+		assert_equals(rem_icmp.mtu, 1400)
+		rem_ipip = rem_icmp.payload
+		assert isinstance(rem_ipip, IPv6)
+		assert_equals(rem_ipip.src, self.VIP)
+		assert_equals(rem_ipip.dst, self.SELF_HOST_V6)
+		assert_equals(rem_ipip.sport, 80)
+		assert_equals(rem_ipip.dport, eph_port)
+
+
+	def _establish_conn(self, dport):
+		seq_no = random.randint(0, 2**32-1)
 		eph_port = random.randint(30000, 60000)
 
-		# force RST for this tuple
-		rst = \
-			IP(dst=self.ALT_HOST) / \
-			UDP(sport=12345, dport=19523) / \
-			GLBGUE(private_data=GLBGUEChainedRouting(hops=[])) / \
-			IPv6(src=self.SELF_HOST_V6, dst=self.VIP) / \
-			TCP(sport=eph_port, dport=22, flags='R', seq=1234)
-		send(rst)
+		self._reset_conn(eph_port, dport, seq_no)
 
 		# create connection to the VIP on the alt host, which will accept the SYN
 		syn = \
@@ -180,22 +213,29 @@ class TestGLBRedirectModuleV6OnV4(GLBTestHelpers):
 			UDP(sport=12345, dport=19523) / \
 			GLBGUE(private_data=GLBGUEChainedRouting(hops=[])) / \
 			IPv6(src=self.SELF_HOST_V6, dst=self.VIP) / \
-			TCP(sport=eph_port, dport=22, flags='S', seq=1234)
+			TCP(sport=eph_port, dport=dport, flags='S', seq=seq_no)
 
 		# retrieve the SYN-ACK
-		resp_ip = self._sendrecv6(syn, filter='ip6 host {} and port 22'.format(self.VIP))
-		assert isinstance(resp_ip, IPv6)
-		assert_equals(resp_ip.src, self.VIP)
-		assert_equals(resp_ip.dst, self.SELF_HOST_V6)
+		syn_ack = self._sendrecv6(syn, lfilter=self._match_tuple(self.VIP, self.SELF_HOST_V6, dport, eph_port))
 
-		# send a Packet Too Big message via PROXY, which
-		# should end up on the alt host
-		pkt = \
-			IP(dst=self.PROXY_HOST) / \
+		seq_no = syn_ack.ack
+		ack_no = syn_ack.seq+1
+
+		ack = \
+			IP(dst=self.ALT_HOST) / \
 			UDP(sport=12345, dport=19523) / \
-			GLBGUE(private_data=GLBGUEChainedRouting(hops=[self.ALT_HOST, self.PROXY_HOST])) / \
+			GLBGUE(private_data=GLBGUEChainedRouting(hops=[])) / \
 			IPv6(src=self.SELF_HOST_V6, dst=self.VIP) / \
-			ICMPv6PacketTooBig(mtu=1400) / \
-			IPv6(src=self.VIP, dst=self.SELF_HOST_V6) / \
-			TCP(sport=22, dport=eph_port)
-		send(pkt)
+			TCP(sport=eph_port, dport=dport, flags='A', seq=seq_no, ack=ack_no)
+		send(ack)
+
+		return (eph_port, seq_no, ack_no)
+
+	def _reset_conn(self, sport, dport, seq):
+		rst = \
+			IP(dst=self.ALT_HOST) / \
+			UDP(sport=12345, dport=19523) / \
+			GLBGUE(private_data=GLBGUEChainedRouting(hops=[])) / \
+			IPv6(src=self.SELF_HOST_V6, dst=self.VIP) / \
+			TCP(sport=sport, dport=dport, flags='R', seq=seq)
+		send(rst)


### PR DESCRIPTION
Path MTU discovery requires that Packet Too Big messages are delivered
to the machine "responsible" for a given flow. Modify glb-redirect
so that it reconstructs the original flow tuple from the ICMP message,
and make it pass such messages along the chain.

Add a helper function which creates a fake TCP header from
the ICMP payload, adjusting for the direction of the flow.

This is then used to check whether a connection is known locally.

Fixes #47