### PR TITLE
Pin versions and downgrade Scapy.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-nose
-pyroute2
-scapy
-siphash
-netaddr
+nose==1.3.7
+pyroute2==0.5.3
+scapy==2.4.0
+siphash==0.0.1
+netaddr==0.7.19


### PR DESCRIPTION
The latest Scapy upgraded quietly and broke tests because it can't detect local routes anymore, so the tests started using broadcast MAC addresses.