### PR TITLE
install rake gem dependency for build environment

### DIFF
--- a/script/Dockerfile.stretch
+++ b/script/Dockerfile.stretch
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y golang golang-glide
 
 # fpm for packaging
 RUN apt-get update && apt-get install -y ruby ruby-dev rubygems build-essential
-RUN gem install --no-ri --no-rdoc fpm
+RUN gem install --no-ri --no-rdoc rake fpm
 
 # patch DKMS for source package generation https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=832558
 ADD helpers/dkms.diff /root/dkms.diff


### PR DESCRIPTION
This addresses #54 

Install rake, which allow you to complete installing the native extensions necessary for FPM