### PR TITLE
glb-redirect: allow standalone mkdeb invocation

### DIFF
--- a/src/glb-redirect/Makefile
+++ b/src/glb-redirect/Makefile
@@ -1,4 +1,6 @@
 KDIR?=/usr/src/linux-headers-$(shell uname -r)
+BUILDDIR?=.
+
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 DKMS_MOD_VER:=$(shell grep 'PACKAGE_VERSION' dkms.conf | cut -d'=' -f2)
@@ -13,7 +15,7 @@ kmod:
 clean:
 	# we allow the following to fail since in our Docker build env we don't have a valid KDIR
 	$(BUILD_VARS) make -C $(KDIR) M=$(ROOT_DIR) clean || true
-	rm -rf libxt_GLBREDIRECT.so
+	rm -rf libxt_GLBREDIRECT.so $(BUILDDIR)/glb-redirect-iptables-dkms_$(DKMS_MOD_VER)_*.deb
 
 .PHONY: lib
 lib: libxt_GLBREDIRECT.so
@@ -35,9 +37,10 @@ IPT_LDFLAGS=-lxtables -shared
 mkdeb:
 	rm -rf glb-redirect-iptables-dkms-mkdeb
 	cp -R /etc/dkms/template-dkms-mkdeb/ glb-redirect-iptables-dkms-mkdeb
+	chown : -R glb-redirect-iptables-dkms-mkdeb
 	# Works around this bug: https://ubuntuforums.org/showthread.php?t=2234906
 	sed -i '/chmod 644/d' glb-redirect-iptables-dkms-mkdeb/Makefile
 	sed -i '/^Depends:/ s/$$/, pkg-config, libxtables12 | libxtables10, libxtables-dev | libxtables10/' glb-redirect-iptables-dkms-mkdeb/debian/control
 	sed -i 's/^Maintainer: .*/Maintainer: GitHub <opensource+glb-director@github.com>/' glb-redirect-iptables-dkms-mkdeb/debian/control
 	dkms mkdeb --source-only
-	mv ../glb-redirect-iptables-dkms_$(DKMS_MOD_VER)_all.deb $(BUILDDIR)/
+	mv ../glb-redirect-iptables-dkms_$(DKMS_MOD_VER)_*.deb $(BUILDDIR)/


### PR DESCRIPTION
Since we only use glb-redirect, it's useful for us to be able to
make mkdeb just for glb-redirect. Fix up the Makefile to make this
possible.