### PR TITLE
Update package version for glb-redirect to 1.0.5.

### DIFF
--- a/src/glb-redirect/dkms.conf
+++ b/src/glb-redirect/dkms.conf
@@ -1,7 +1,7 @@
 MAKE="make KDIR=/lib/modules/${kernelver}/build"
 CLEAN="make clean"
 PACKAGE_NAME=glb-redirect-iptables
-PACKAGE_VERSION=1.0.4
+PACKAGE_VERSION=1.0.5
 REMAKE_INITRD=no
 
 BUILT_MODULE_NAME=ipt_GLBREDIRECT


### PR DESCRIPTION
Picks up a few good bug fixes that landed in `master` but haven't seen a release yet.