### PR TITLE
Clear our skb timestamp to unbreak fq

### DIFF
--- a/src/glb-redirect/ipt_GLBREDIRECT.c
+++ b/src/glb-redirect/ipt_GLBREDIRECT.c
@@ -106,6 +106,13 @@ static unsigned int glbredirect_send_forwarded_skb(struct net *net, struct sk_bu
 		return NF_STOLEN;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,0)
+	/* Clear out timestamp to make forwarding work with fq on Linux 5.4:
+	 * - https://github.com/torvalds/linux/commit/9669fffc1415bb0c
+	 */
+	skb->tstamp = 0;
+#endif
+
 	PRINT_DEBUG(KERN_ERR " -> forwarded to alternate\n");
 	ip_local_out(net, skb->sk, skb);
 

--- a/src/glb-redirect/ipt_GLBREDIRECT.c
+++ b/src/glb-redirect/ipt_GLBREDIRECT.c
@@ -108,7 +108,7 @@ static unsigned int glbredirect_send_forwarded_skb(struct net *net, struct sk_bu
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,0)
 	/* Clear out timestamp to make forwarding work with fq on Linux 5.4:
-	 * - https://github.com/torvalds/linux/commit/9669fffc1415bb0c
+	 * - https://github.com/torvalds/linux/commit/8203e2d844d34af2
 	 */
 	skb->tstamp = 0;
 #endif


### PR DESCRIPTION
Strictly speaking, https://github.com/torvalds/linux/commit/8203e2d844d34 is included since Linux 4.20 and the condition may need to be more relaxed. We only run LTS versions, so 4.19 and 5.4 are the only two kernels I tested on.

Eric Dumazet blessed this change:

![image](https://user-images.githubusercontent.com/89186/67819426-51f90200-fa72-11e9-8a83-6beb40adc4db.png)

And we can finally see Linux 5.4 not aiming to send the next packet in 50 years:

* https://lists.openwall.net/netdev/2019/10/29/177

Before:

```
qdisc fq 1: dev ext0 root refcnt 65 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 3228 initial_quantum 16140 low_rate_threshold 550Kbit refill_delay 40.0ms
 Sent 4872143400 bytes 8448638 pkt (dropped 201276670, overlimits 0 requeues 103)
 backlog 779376b 10000p requeues 103
  2806 flows (2688 inactive, 118 throttled), next packet delay 1572240566653952889 ns
  354201 gc, 0 highprio, 804560 throttled, 3919 ns latency, 19492 flows_plimit
```

After:

```
qdisc fq 1: dev ext0 root refcnt 65 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 3228 initial_quantum 16140 low_rate_threshold 550Kbit refill_delay 40.0ms
 Sent 10895663950 bytes 18301540 pkt (dropped 341, overlimits 0 requeues 439)
 backlog 7570b 4p requeues 439
  2777 flows (2775 inactive, 2 throttled), next packet delay 42582 ns
  819921 gc, 10 highprio, 1675956 throttled, 2879 ns latency, 341 flows_plimit
```