### PR TITLE
Add simple actions CI job to run cibuild-create-packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: package-build
 
 on: [push]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
-name: package-build
+name: ci
 
 on: [push]
 
 jobs:
-  build:
+  package-build:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run package build
+      run: script/cibuild-create-packages


### PR DESCRIPTION
This at least validates builds in a consistent way using CI. Ideally we'd get the full test suite running too, but I need to look more into what's supported there with actions since it uses Vagrant right now.