### PR TITLE
glb-director: Enable systemd ready notification.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y tcpdump net-tools tshark build-essential libxtables-dev linux-headers-$(uname -r) python-pip jq bird curl
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tcpdump net-tools tshark build-essential libxtables-dev linux-headers-$(uname -r) python-pip jq bird curl libsystemd-dev
     groupadd wireshark || true
     usermod -a -G wireshark vagrant || true
     chgrp wireshark /usr/bin/dumpcap

--- a/script/Dockerfile.stretch
+++ b/script/Dockerfile.stretch
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get -y install curl
 
 # DPDK 
 RUN curl -s https://packagecloud.io/install/repositories/github/unofficial-dpdk-stable/script.deb.sh | bash
-RUN apt-get update && apt-get install -y build-essential dpdk dpdk-dev wget pkg-config libjansson-dev
+RUN apt-get update && apt-get install -y build-essential dpdk dpdk-dev wget pkg-config libjansson-dev libsystemd-dev
 
 # iptables / DKMS
 RUN apt-get update && apt-get install -y iptables-dev dkms debhelper libxtables-dev

--- a/src/glb-director/Makefile
+++ b/src/glb-director/Makefile
@@ -49,10 +49,12 @@ CFLAGS += -O3 -g
 CFLAGS += $(WERROR_FLAGS)
 CFLAGS += -pie -fPIE -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -fstack-protector-strong
 CFLAGS += -DSTATSD
+CFLAGS += -DSYSTEMD
 #CFLAGS += -DGLB_DUMP_FULL_PACKET
 
 LDFLAGS += -z relro -z now
 LDFLAGS += -ljansson
+LDFLAGS += -lsystemd
 
 # disable since libxenstore.so isn't linked properly
 CONFIG_RTE_LIBRTE_PMD_XENVIRT = n

--- a/src/glb-director/main.c
+++ b/src/glb-director/main.c
@@ -79,6 +79,10 @@
 #include <rte_string_fns.h>
 #include <rte_udp.h>
 
+#ifdef SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 #include "bind_classifier.h"
 #include "config.h"
 #include "glb_control_loop.h"
@@ -422,6 +426,16 @@ int main(int argc, char **argv)
 	{
 		rte_eal_remote_launch(main_loop_processor, glb_lcore_contexts[i], i);
 	}
+
+#ifdef SYSTEMD
+	/* Now that all processing workers are running, we can notify systemd
+	 * we're ready. We follow the systemd doc suggestion of ignoring the 
+	 * return value so we can call this even if we're not being run under
+	 * systemd, or without the socket.
+	 */
+	sd_notify(0, "READY=1");
+#endif
+
 	main_loop_control(NULL);
 	RTE_LCORE_FOREACH_SLAVE(i)
 	{

--- a/src/glb-director/packaging/glb-director.service
+++ b/src/glb-director/packaging/glb-director.service
@@ -4,7 +4,8 @@ After=network.target network-online.target
 Wants=network-online.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
 Restart=always
 EnvironmentFile=/etc/default/glb-director
 ExecStart=/usr/sbin/glb-director $GLB_DIRECTOR_EAL_ARGS -- --config-file ${GLB_DIRECTOR_CONFIG_FILE} --forwarding-table ${GLB_DIRECTOR_FORWARDING_TABLE}

--- a/src/glb-director/packaging/glb-director.service
+++ b/src/glb-director/packaging/glb-director.service
@@ -4,7 +4,9 @@ After=network.target network-online.target
 Wants=network-online.target
 
 [Service]
+# Allow the service to notify systemd when it has finished activating.
 Type=notify
+# NotifyAccess will allow the main pid to send the above ready message (which is also the default).
 NotifyAccess=main
 Restart=always
 EnvironmentFile=/etc/default/glb-director


### PR DESCRIPTION
Currently when starting glb-director using systemd, there's no way to use systemd dependencies to trigger subsequent services once glb-director is actually started.

By adding this call to [sd_notify](https://www.freedesktop.org/software/systemd/man/sd_notify.html#), and setting the service to `Type=notify`, systemd will understand that the service isn't fully started until it has loaded the initial forwarding table and all workers are launched and ready to process packets.