### PR TITLE
GLB health-checks: parameter configurability: 

### DIFF
--- a/docs/setup/forwarding-table-config.md
+++ b/docs/setup/forwarding-table-config.md
@@ -115,4 +115,4 @@ If `glb-healthcheck` is used, a backend will be considered down if either the `g
 
 ## Healthcheck configuration options
 
-Refer [GLB Healthcheck Configuration](../development/glb-healthcheck-configuration.md) for more details. 
+Refer [GLB Healthcheck Configuration](glb-healthcheck-configuration.md) for more details. 

--- a/docs/setup/forwarding-table-config.md
+++ b/docs/setup/forwarding-table-config.md
@@ -115,15 +115,4 @@ If `glb-healthcheck` is used, a backend will be considered down if either the `g
 
 ## Healthcheck configuration options
 
-`/etc/glb/healthcheck.conf` defines the few values that need to be configured to use the healthchecker. For most use cases, the default will work:
-```
-{
-  "forwarding_table": {
-    "src": "/etc/glb/forwarding_table.src.json",
-    "dst": "/etc/glb/forwarding_table.checked.json"
-  },
-  "reload_command": "glb-director-cli build-config /etc/glb/forwarding_table.checked.json /etc/glb/forwarding_table.checked.bin && systemctl reload glb-director"
-}
-```
-
-This instructs the healthchecker to load `/etc/glb/forwarding_table.src.json`, perform any checks defined inside it, and keep a `/etc/glb/forwarding_table.checked.json` up to date with valid/live health state. Any time it changes the `dst` file, it also runs the reload command (which in this case compiles the table and reloads the director to pick up those changes).
+Refer [GLB Healthcheck Configuration](../development/glb-healthcheck-configuration.md) for more details. 

--- a/docs/setup/glb-healthcheck-configuration.md
+++ b/docs/setup/glb-healthcheck-configuration.md
@@ -42,7 +42,7 @@ Specifies the commands to run upon creation, by `glb-healthcheck`, of a new/upda
 Health-checking configuration related to the actual sending of the probes and the receiving of the responses is listed in this file:
 ```
 {
- "healthcheck_defaults":
+ "healthchecks":
   {
      "interval_ms": 4000,
      "timeout_ms": 2000,
@@ -86,7 +86,7 @@ _mandatory_
 This field specifies the list of back-ends to which glb-director will load-balance the traffic. The list of back-ends for which to do the health-checking, is determined by the presence of "healthchecks" for the resepctive backends. 
 
 If health-checking is not desired for a specific back-end, the parameters under "healthchecks" for that back-end can be omitted.
-If present, then along with the settings under "healthcheck_defaults" it determines the characteristics of health-checking for the back-ends listed.
+If present, then along with the settings under "healthchecks" it determines the characteristics of health-checking for the back-ends listed.
 
 For each back-end listed, health-check probes of the specified protocol are sent to its IP and port as listed.
 

--- a/docs/setup/glb-healthcheck-configuration.md
+++ b/docs/setup/glb-healthcheck-configuration.md
@@ -37,13 +37,28 @@ This instructs the healthchecker to load `/etc/glb/forwarding_table.src.json`, p
 Specifies the commands to run upon creation, by `glb-healthcheck`, of a new/updated destination JSON.
  
 ## `/etc/glb/forwarding_table.src.json`
-Health-checking related fields that apply to all back-ends listed in this file:
 
+Health-checking configuration related to the actual sending of the probes and the receiving of the responses is listed in this file:
+```
+{
+ "healthcheck_defaults":
+  {
+     "interval_ms": 4000,
+     "timeout_ms": 2000,
+     "trigger": 4
+  }
+  "tables":
+  {
+     "backends": [{ "ip": "<a.b.c.d>", "state": "<state-name>", "healthchecks": {"<protocol>": <port-number>, "<tunnel-type>": <gue-port-number>, "http_uri": "<URL if protocol is "http">" } }]
+  }
+}
+```
 ### timeout_ms
 _optional_
 
 This field specifies the duration of time, in milli seconds, that is allowed for a response of health-check probe to received.
 At the conclusion of this duration, in the absence of a response the health-check is considered to have failed due to a timeout.
+It applies to all back-ends for which health-checking is enabled.
 
 By default, 1 second.
 
@@ -51,6 +66,8 @@ By default, 1 second.
 _optional_
 
 This field specifies the duration of time, in milli seconds, between successive health-check probes sent to a given a L7 back-end.
+It applies to all back-ends for which health-checking is enabled.
+
 By default, 2 seconds.
 
 ### trigger
@@ -58,4 +75,34 @@ _optional_
 
 This field specifies the count of consecutive failing health-checks of a given healthy back-end that causes that back-end to be marked unhealthy.
 Similarly, for an unhealthy back-end this specifies the count of consecutive succeeding health-checks that cause that back-end to be marked healthy.
+It applies to all back-ends for which health-checking is enabled.
+
 By default, 3.
+
+### backends
+_mandatory_
+
+This field specifies the list of back-ends to which glb-director will load-balance the traffic. The list of back-ends for which to do the health-checking, is determined by the presence of "healthchecks" for the resepctive backends. 
+
+If health-checking is not desired for a specific back-end, the parameters under "healthchecks" for that back-end can be omitted.
+If present, then along with the settings under "healthcheck_defaults" it determines the characteristics of health-checking for the back-ends listed.
+
+For each back-end listed, health-check probes of the specified protocol are sent to its IP and port as listed.
+
+Currently supported protocols are:
+```
+    http
+    tcp
+``` 
+Additionally, for the tunnel between a glb-director and a back-end, health-checking of the tunnel is supported for tunnels of the following types:
+```
+    gue
+    fou
+```
+State maybe one of the following:
+```
+    filling
+    active
+    draining
+    inactive
+```

--- a/docs/setup/glb-healthcheck-configuration.md
+++ b/docs/setup/glb-healthcheck-configuration.md
@@ -28,8 +28,9 @@ The configuration for `glb-healthcheck` component is present by default at:
 ```
 
 ### forwarding_table
-####`src` and `dst`: configuration for the file-path for the source and destination JSON files to be processed by `glb-healthcheck`.
-By default, `src` is `/etc/glb/forwarding_table.src.json`; and `dst` is `/etc/glb/forwarding_table.checked.json`.
+####`src` and `dst`
+
+These fields specify the file paths for the source and destination JSON files to be processed by `glb-healthcheck`. By default, `src` is `/etc/glb/forwarding_table.src.json`; and `dst` is `/etc/glb/forwarding_table.checked.json`.
 
 This instructs the healthchecker to load `/etc/glb/forwarding_table.src.json`, perform any checks defined inside it, and keep a `/etc/glb/forwarding_table.checked.json` up to date with valid/live health state. Any time it changes the `dst` file, it also runs the reload command (which in this case compiles the table and reloads the director to pick up those changes).
 

--- a/docs/setup/glb-healthcheck-configuration.md
+++ b/docs/setup/glb-healthcheck-configuration.md
@@ -47,7 +47,7 @@ Health-checking configuration related to the actual sending of the probes and th
      "interval_ms": 4000,
      "timeout_ms": 2000,
      "trigger": 4
-  }
+  },
   "tables":
   {
      "backends": [{ "ip": "<a.b.c.d>", "state": "<state-name>", "healthchecks": {"<protocol>": <port-number>, "<tunnel-type>": <gue-port-number>, "http_uri": "<URL if protocol is "http">" } }]

--- a/docs/setup/glb-healthcheck-configuration.md
+++ b/docs/setup/glb-healthcheck-configuration.md
@@ -53,6 +53,14 @@ Health-checking configuration related to the actual sending of the probes and th
   }
 }
 ```
+### interval_ms
+_optional_
+
+This field specifies the duration of time, in milli seconds, between successive health-check probes sent to a given a L7 back-end.
+It applies to all back-ends for which health-checking is enabled.
+
+By default, 2 seconds.
+
 ### timeout_ms
 _optional_
 
@@ -61,14 +69,6 @@ At the conclusion of this duration, in the absence of a response the health-chec
 It applies to all back-ends for which health-checking is enabled.
 
 By default, 1 second.
-
-### interval_ms
-_optional_
-
-This field specifies the duration of time, in milli seconds, between successive health-check probes sent to a given a L7 back-end.
-It applies to all back-ends for which health-checking is enabled.
-
-By default, 2 seconds.
 
 ### trigger
 _optional_

--- a/docs/setup/glb-healthcheck-configuration.md
+++ b/docs/setup/glb-healthcheck-configuration.md
@@ -1,0 +1,48 @@
+# glb-healthcheck configuration
+
+The `glb-healthcheck` component is the application that sends probes to determine liveliness of the 
+L7 back-ends for which `glb-director` is acting as an L4 load-balancer.
+
+
+`glb-healthcheck` does the health-checking for those L7 back-ends which are listed in the configuration for `glb-director`.
+ It processes two json files: 
+* A source JSON file: to learn the identities of the L7 back-ends whose health is to be checked. This file also lists the protocol to use and the specific protocol-parameters to use when crafting the health-check probes. By default this file is present at `/etc/glb/forwarding_table.src.json`.
+* A destination JSON file: to which `glb-healthcheck` writes the contents of this file along with health-status for each of the L7 back-ends listed in the `source JSON file`. The `glb-director CLI` converts this json file into a `.bin` file which serves as the configuration file to be read by `glb-director`. 
+By default this file is present at `/etc/glb/forwarding_table.checked.json`.
+  
+The configuration for `glb-healthcheck` component is present by default at:
+* `/etc/glb/healthcheck.conf`: This file lists the locations of the 2 json files processed by `glb-healthcheck`.
+* `/etc/glb/forwarding_table.src.json`: This file provides the configuration for `glb-director` if health-checking of the L7 back-ends is not to be performed. It also provides configuration for `glb-healthcheck` for the actual sending of the probes.
+
+## `/etc/glb/healthcheck.conf`
+
+### forwarding_table
+Under `src` and `dst`: configuration for the file-path for the source and destination JSON files to be processed by `glb-healthcheck`.
+By default, `src` is `/etc/glb/forwarding_table.src.json`; and `dst` is `/etc/glb/forwarding_table.checked.json` .
+
+### reload_command
+Specifies the commands to run upon creation, by `glb-healthcheck`, of a new/updated destination JSON.
+ 
+## `/etc/glb/forwarding_table.src.json`
+Health-checking related fields that apply to all back-ends listed in this file:
+
+### timeout_ms
+_optional_
+
+This field specifies the duration of time, in milli seconds, that is allowed for a response of health-check probe to received.
+At the conclusion of this duration, in the absence of a response the health-check is considered to have failed due to a timeout.
+
+By default, 1 second.
+
+### interval_ms
+_optional_
+
+This field specifies the duration of time, in milli seconds, between successive health-check probes sent to a given a L7 back-end.
+By default, 2 seconds.
+
+### trigger
+_optional_
+
+This field specifies the count of consecutive failing health-checks of a given healthy back-end that causes that back-end to be marked unhealthy.
+Similarly, for an unhealthy back-end this specifies the count of consecutive succeeding health-checks that cause that back-end to be marked healthy.
+By default, 3.

--- a/src/glb-healthcheck/GLBTable.go
+++ b/src/glb-healthcheck/GLBTable.go
@@ -77,7 +77,7 @@ type GLBHealthGlobalConfig struct {
 }
 
 type GLBGlobalConfig struct {
-	HealthcheckGlobalCfg *GLBHealthGlobalConfig `json:"healthcheck_defaults"`
+	HealthcheckGlobalCfg *GLBHealthGlobalConfig `json:"healthchecks"`
 	Tables               []*GLBTable            `json:"tables"`
 }
 

--- a/src/glb-healthcheck/GLBTable.go
+++ b/src/glb-healthcheck/GLBTable.go
@@ -35,6 +35,7 @@ package main
 import (
 	"encoding/json"
 	"io/ioutil"
+	"time"
 )
 
 type GLBHealthcheckConfig struct {
@@ -69,17 +70,24 @@ type GLBTable struct {
 	Backends []*GLBBackend `json:"backends"`
 }
 
-type GLBTableConfig struct {
-	Tables []*GLBTable `json:"tables"`
+type GLBHealthGlobalConfig struct {
+	TimeoutMilliSec  time.Duration `json:"timeout_ms,omitempty"`
+	IntervalMilliSec time.Duration `json:"interval_ms,omitempty"`
+	Trigger          int           `json:"trigger,omitempty"`
 }
 
-func LoadGLBTableConfig(filename string) (*GLBTableConfig, error) {
+type GLBGlobalConfig struct {
+	HealthcheckGlobalCfg *GLBHealthGlobalConfig `json:"healthcheck_global_cfg"`
+	Tables               []*GLBTable            `json:"tables"`
+}
+
+func LoadGLBTableConfig(filename string) (*GLBGlobalConfig, error) {
 	bytes, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
 
-	c := &GLBTableConfig{}
+	c := &GLBGlobalConfig{}
 	err = json.Unmarshal(bytes, c)
 	if err != nil {
 		return nil, err
@@ -88,7 +96,7 @@ func LoadGLBTableConfig(filename string) (*GLBTableConfig, error) {
 	return c, nil
 }
 
-func (cfg *GLBTableConfig) WriteToFile(filename string) error {
+func (cfg *GLBGlobalConfig) WriteToFile(filename string) error {
 	bytes, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return err

--- a/src/glb-healthcheck/GLBTable.go
+++ b/src/glb-healthcheck/GLBTable.go
@@ -77,7 +77,7 @@ type GLBHealthGlobalConfig struct {
 }
 
 type GLBGlobalConfig struct {
-	HealthcheckGlobalCfg *GLBHealthGlobalConfig `json:"healthcheck_global_cfg"`
+	HealthcheckGlobalCfg *GLBHealthGlobalConfig `json:"healthcheck_defaults"`
 	Tables               []*GLBTable            `json:"tables"`
 }
 

--- a/src/glb-healthcheck/HealthCheckManager.go
+++ b/src/glb-healthcheck/HealthCheckManager.go
@@ -41,11 +41,6 @@ import (
 )
 
 var (
-	SuccessesBeforeMarkedHealthy = 3
-	FailuresBeforeMarkedFailed   = 3
-)
-
-var (
 	managerCounters = expvar.NewMap("HealthCheckManager")
 )
 
@@ -65,7 +60,8 @@ type HealthCheckManager struct {
 	results     map[HealthCheckTarget]HealthResult
 }
 
-func NewHealthCheckManager(checkTimeout time.Duration, checkInterval time.Duration) *HealthCheckManager {
+func NewHealthCheckManager(checkTimeout time.Duration, checkInterval time.Duration, triggerHealthy int,
+	triggerUnhealthy int) *HealthCheckManager {
 	tunnelChecker := &TunnelHealthChecker{}
 	tunnelChecker.Initialize(checkTimeout)
 

--- a/src/glb-healthcheck/HealthCheckManager.go
+++ b/src/glb-healthcheck/HealthCheckManager.go
@@ -120,7 +120,8 @@ func (hhc *HealthCheckManager) GetResults() map[HealthCheckTarget]HealthResult {
 // most importantly, we take a snapshot in time each check interval and use that
 // as the source of truth for that round, no mutations. next round we do
 // housekeeping like accepting new targets and throwing away ones that are gone.
-func (hhc *HealthCheckManager) Run(roundComplete chan bool) {
+func (hhc *HealthCheckManager) Run(roundComplete chan bool, SuccessesBeforeMarkedHealthy int,
+	FailuresBeforeMarkedFailed int) {
 	activeTargets := make(map[HealthCheckTarget]*HealthCheckMetadata)
 
 	for {

--- a/src/glb-healthcheck/HealthCheckerAppContext.go
+++ b/src/glb-healthcheck/HealthCheckerAppContext.go
@@ -63,7 +63,7 @@ type HealthCheckerAppContext struct {
 	checkManager *HealthCheckManager
 
 	sync.Mutex
-	forwardingTableConfig *GLBTableConfig
+	forwardingTableConfig *GLBGlobalConfig
 	dirty                 bool
 	nextAllowedDirtyClear time.Time
 }
@@ -205,8 +205,7 @@ func (ctx *HealthCheckerAppContext) LoadForwardingTable() error {
 	// also allow write outs immediately, since this was an explicit (externally requested) reload
 	ctx.nextAllowedDirtyClear = time.Now()
 	ctx.Unlock()
-
-	return ctx.SyncBackendsToCheckManager()
+	return nil
 }
 
 func (ctx *HealthCheckerAppContext) SyncAndMaybeReload() {

--- a/src/glb-healthcheck/main.go
+++ b/src/glb-healthcheck/main.go
@@ -91,7 +91,7 @@ Options:
 
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&
 		ctx.forwardingTableConfig.HealthcheckGlobalCfg.TimeoutMilliSec != 0 {
-		HealthCheckTimeout = ctx.forwardingTableConfig.HealthcheckGlobalCfg.TimeoutMilliSec * 1000000
+		HealthCheckTimeout = ctx.forwardingTableConfig.HealthcheckGlobalCfg.TimeoutMilliSec * time.Millisecond
 	}
 
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&

--- a/src/glb-healthcheck/main.go
+++ b/src/glb-healthcheck/main.go
@@ -90,29 +90,29 @@ Options:
 		return
 	}
 	
-	HealthCheckTimeout := DefaultHealthCheckTimeout
+	healthCheckTimeout := DefaultHealthCheckTimeout
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&
 		ctx.forwardingTableConfig.HealthcheckGlobalCfg.TimeoutMilliSec != 0 {
-		HealthCheckTimeout = ctx.forwardingTableConfig.HealthcheckGlobalCfg.TimeoutMilliSec * time.Millisecond
+		healthCheckTimeout = ctx.forwardingTableConfig.HealthcheckGlobalCfg.TimeoutMilliSec * time.Millisecond
 	}
 
-	HealthCheckInterval := DefaultHealthCheckInterval
+	healthCheckInterval := DefaultHealthCheckInterval
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&
 		ctx.forwardingTableConfig.HealthcheckGlobalCfg.IntervalMilliSec != 0 {
-		HealthCheckInterval = ctx.forwardingTableConfig.HealthcheckGlobalCfg.IntervalMilliSec * time.Millisecond
+		healthCheckInterval = ctx.forwardingTableConfig.HealthcheckGlobalCfg.IntervalMilliSec * time.Millisecond
 	}
 
-	SuccessesBeforeMarkedHealthy := DefaultSuccessesBeforeMarkedHealthy
-	FailuresBeforeMarkedFailed := DefaultFailuresBeforeMarkedFailed
+	successesBeforeMarkedHealthy := DefaultSuccessesBeforeMarkedHealthy
+	failuresBeforeMarkedFailed := DefaultFailuresBeforeMarkedFailed
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&
 		ctx.forwardingTableConfig.HealthcheckGlobalCfg.Trigger != 0 {
-		SuccessesBeforeMarkedHealthy = ctx.forwardingTableConfig.HealthcheckGlobalCfg.Trigger
-		FailuresBeforeMarkedFailed   = ctx.forwardingTableConfig.HealthcheckGlobalCfg.Trigger
+		successesBeforeMarkedHealthy = ctx.forwardingTableConfig.HealthcheckGlobalCfg.Trigger
+		failuresBeforeMarkedFailed   = ctx.forwardingTableConfig.HealthcheckGlobalCfg.Trigger
 	}
 
 	// the check manager will run the HC loop and manage most of the HC part of the work
-	ctx.checkManager = NewHealthCheckManager(HealthCheckTimeout, HealthCheckInterval, SuccessesBeforeMarkedHealthy,
-		FailuresBeforeMarkedFailed)
+	ctx.checkManager = NewHealthCheckManager(healthCheckTimeout, healthCheckInterval, successesBeforeMarkedHealthy,
+		failuresBeforeMarkedFailed)
 
 	err = ctx.SyncBackendsToCheckManager()
 	if err != nil {

--- a/src/glb-healthcheck/main.go
+++ b/src/glb-healthcheck/main.go
@@ -127,7 +127,7 @@ Options:
 
 	// run the check manager, and let it notify us whenever a HC round completed
 	healthRoundComplete := make(chan bool)
-	go ctx.checkManager.Run(healthRoundComplete, SuccessesBeforeMarkedHealthy, FailuresBeforeMarkedFailed)
+	go ctx.checkManager.Run(healthRoundComplete, successesBeforeMarkedHealthy, failuresBeforeMarkedFailed)
 
 	// handle SIGHUP and reload our forwarding table
 	sigs := make(chan os.Signal, 1)

--- a/src/glb-healthcheck/main.go
+++ b/src/glb-healthcheck/main.go
@@ -96,7 +96,7 @@ Options:
 
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&
 		ctx.forwardingTableConfig.HealthcheckGlobalCfg.IntervalMilliSec != 0 {
-		HealthCheckInterval = ctx.forwardingTableConfig.HealthcheckGlobalCfg.IntervalMilliSec * 1000000
+		HealthCheckInterval = ctx.forwardingTableConfig.HealthcheckGlobalCfg.IntervalMilliSec * time.Millisecond
 	}
 
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&

--- a/src/glb-healthcheck/main.go
+++ b/src/glb-healthcheck/main.go
@@ -42,17 +42,18 @@ import (
 	"time"
 )
 
-var (
+const (
 	// timeout should be < interval
-	HealthCheckTimeout  = 1 * time.Second
-	HealthCheckInterval = 2 * time.Second
+	DefaultHealthCheckTimeout  = 1 * time.Second
+	DefaultHealthCheckInterval = 2 * time.Second
 )
 
 // Default values for the marking-thresholds for marking backends (un)healthy
-var (
-	SuccessesBeforeMarkedHealthy = 3
-	FailuresBeforeMarkedFailed   = 3
+const (
+	DefaultSuccessesBeforeMarkedHealthy = 3
+	DefaultFailuresBeforeMarkedFailed = 3
 )
+
 func main() {
 	usage := `GLB Director->Proxy Healthcheck Service
 
@@ -88,17 +89,21 @@ Options:
 		ctx.logContext.Fatalf("Could not load initial forwarding table: %v", err)
 		return
 	}
-
+	
+	HealthCheckTimeout := DefaultHealthCheckTimeout
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&
 		ctx.forwardingTableConfig.HealthcheckGlobalCfg.TimeoutMilliSec != 0 {
 		HealthCheckTimeout = ctx.forwardingTableConfig.HealthcheckGlobalCfg.TimeoutMilliSec * time.Millisecond
 	}
 
+	HealthCheckInterval := DefaultHealthCheckInterval
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&
 		ctx.forwardingTableConfig.HealthcheckGlobalCfg.IntervalMilliSec != 0 {
 		HealthCheckInterval = ctx.forwardingTableConfig.HealthcheckGlobalCfg.IntervalMilliSec * time.Millisecond
 	}
 
+	SuccessesBeforeMarkedHealthy := DefaultSuccessesBeforeMarkedHealthy
+	FailuresBeforeMarkedFailed := DefaultFailuresBeforeMarkedFailed
 	if ctx.forwardingTableConfig.HealthcheckGlobalCfg != nil &&
 		ctx.forwardingTableConfig.HealthcheckGlobalCfg.Trigger != 0 {
 		SuccessesBeforeMarkedHealthy = ctx.forwardingTableConfig.HealthcheckGlobalCfg.Trigger
@@ -122,7 +127,7 @@ Options:
 
 	// run the check manager, and let it notify us whenever a HC round completed
 	healthRoundComplete := make(chan bool)
-	go ctx.checkManager.Run(healthRoundComplete)
+	go ctx.checkManager.Run(healthRoundComplete, SuccessesBeforeMarkedHealthy, FailuresBeforeMarkedFailed)
 
 	// handle SIGHUP and reload our forwarding table
 	sigs := make(chan os.Signal, 1)


### PR DESCRIPTION
Configured values apply for all backends across all tables.

Config stanza: in /etc/glb/forwarding_table.src.json (same level as tables[]):
eg.

    {
     "healthcheck_global_cfg":
      {
         "interval_ms": 4000,
         "timeout_ms": 2000,
         "trigger": 4
      }
   }
Interval & timeout values are in milli-seconds.
Timeout value should be less than the interval.
Trigger is an absolute number.