### PR TITLE
glb-healthcheck: Add missing sync call on reload.

### DIFF
--- a/src/glb-healthcheck/main.go
+++ b/src/glb-healthcheck/main.go
@@ -143,7 +143,7 @@ Options:
 
 			err = ctx.SyncBackendsToCheckManager()
 			if err != nil {
-				ctx.logContext.Errorf("Could sync backends after reload: %v", err)
+				ctx.logContext.Errorf("Could not sync backends after reload: %v", err)
 				continue
 			}
 

--- a/src/glb-healthcheck/main.go
+++ b/src/glb-healthcheck/main.go
@@ -141,6 +141,12 @@ Options:
 				continue
 			}
 
+			err = ctx.SyncBackendsToCheckManager()
+			if err != nil {
+				ctx.logContext.Errorf("Could sync backends after reload: %v", err)
+				continue
+			}
+
 			ctx.SyncAndMaybeReload()
 		}
 	}()


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/github/glb-director/commit/43a9a238f0ed88980e949e4e53905fea46b82e26 which separated `SyncBackendsToCheckManager` out of the load function so that at initialisation time some additional work could be done, but missed the other call site during reloads. This adds back the sync in that location.