### PR TITLE
Fix regressions and upstream updates for the Vagrant build

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,29 +14,36 @@ Vagrant.configure("2") do |config|
 
   config.vm.synced_folder "src/glb-wireshark-dissector/", "/home/vagrant/.config/wireshark/plugins/glb-wireshark-dissector", type: 'rsync'
 
-  config.vm.provision :shell, inline: <<-SHELL
+  config.vm.provision "Initial package installation", type: "shell", inline: <<-SHELL
     echo 'deb http://ftp.debian.org/debian stretch-backports main' >/etc/apt/sources.list.d/backports.list
     apt-get update
 
     DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade
     sudo apt install -y -t stretch-backports linux-image-amd64 linux-headers-amd64 iproute2
 
-    DEBIAN_FRONTEND=noninteractive apt-get install -y tcpdump net-tools tshark build-essential libxtables-dev linux-headers-amd64 python-pip jq bird curl libsystemd-dev libbpf-dev
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tcpdump net-tools tshark build-essential libxtables-dev linux-headers-amd64 python-pip jq bird curl libsystemd-dev libbpf-dev apt-transport-https curl software-properties-common
 
     groupadd wireshark || true
     usermod -a -G wireshark vagrant || true
     chgrp wireshark /usr/bin/dumpcap
     chmod 4750 /usr/bin/dumpcap
     pip install -r /vagrant/requirements.txt
+
+    wget --quiet https://golang.org/dl/go1.14.8.linux-amd64.tar.gz -O- | tar -C /usr/local -zxvf -
+    cat >/etc/profile.d/gopath.sh <<'EOF'
+    export GOROOT=/usr/local/go
+    export GOPATH=/go
+    export PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
+EOF
   SHELL
-  config.vm.provision :reload
+  config.vm.provision "Reboot after kernel upgrade", type: "reload"
 
   config.vm.define "router" do |v|
     v.vm.network "private_network", ip: "192.168.40.3", virtualbox__intnet: "glb_user_network"
     v.vm.network "private_network", ip: "192.168.50.2", virtualbox__intnet: "glb_datacenter_network", :mac=> "001122334455"
     v.vm.hostname = "router"
 
-    v.vm.provision :shell, name: 'Enable forwarding and configure router', inline: <<-SHELL
+    v.vm.provision 'Enable forwarding and configure router', type: "shell", inline: <<-SHELL
       if ! grep -q '^net.ipv4.ip_forward' /etc/sysctl.conf; then
         echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
         sysctl -w net.ipv4.ip_forward=1
@@ -50,7 +57,7 @@ Vagrant.configure("2") do |config|
     v.vm.network "private_network", ip: "192.168.40.2", virtualbox__intnet: "glb_user_network"
     v.vm.hostname = "user"
 
-    v.vm.provision :shell, inline: <<-SHELL
+    v.vm.provision "Bring up demo client IPs", type: "shell", inline: <<-SHELL
       /vagrant/script/helpers/configure-vagrant-user.sh
 
       ip addr add 192.168.40.50/24 dev eth1 || true
@@ -81,7 +88,7 @@ Vagrant.configure("2") do |config|
         vb.customize ["setextradata", :id, "VBoxInternal/CPUM/SSE4.2", "1"]
       end
 
-      v.vm.provision "shell", run: "always", inline: <<-SHELL
+      v.vm.provision "Configure mounts and sysctls", type: "shell", run: "always", inline: <<-SHELL
         mkdir -p /mnt/huge
         if ! grep -q 'hugetlbfs' /etc/fstab; then
           echo 'hugetlbfs /mnt/huge hugetlbfs mode=1770 0 0' >>/etc/fstab
@@ -98,43 +105,36 @@ Vagrant.configure("2") do |config|
       SHELL
 
       # install DPDK et al.
-      v.vm.provision "shell", run: "always", inline: <<-SHELL
-        apt-get install -y apt-transport-https curl software-properties-common
-
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 10
-
+      v.vm.provision "Install and configure DPDK", type: "shell", run: "always", inline: <<-SHELL
+        # required for testing or running DPDK
         curl -s https://packagecloud.io/install/repositories/github/unofficial-dpdk-stable/script.deb.sh | sudo bash
         apt-get install -y --force-yes linux-headers-amd64 # dpdk requires this for the current kernel, but won't block if not installed
         apt-get install -y python-pip dpdk-dev=17.11.1-6 dpdk=17.11.1-6 dpdk-rte-kni-dkms dpdk-igb-uio-dkms libjansson-dev
         apt-get install -y valgrind vim tcpdump git
 
-
-        curl -O https://dl.google.com/go/go1.13.6.linux-amd64.tar.gz
-        tar xvf go1.13.6.linux-amd64.tar.gz
-        sudo chown -R root:root ./go
-        sudo mv go /usr/local
-
         echo 'rte_kni' >/etc/modules-load.d/dpdk
         echo 'igb_uio' >>/etc/modules-load.d/dpdk
-      SHELL
 
-      v.vm.provision "shell", run: "always", inline: <<-SHELL
         sudo apt install -y dpdk-rte-kni-dkms dpdk-igb-uio-dkms
         modprobe rte_kni
         modprobe igb_uio
+        
+        # required for testing or running XDP
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 10
+        sudo apt install -y clang-tools-10
       SHELL
 
       if install_example_setup
         # example setup
         if example_setup_type == 'dpdk'
-          v.vm.provision "shell", run: "always", inline: <<-SHELL
+          v.vm.provision "Configure DPDK example setup", type: "shell", run: "always", inline: <<-SHELL
             ifdown eth1
             dpdk-devbind --bind=igb_uio eth1
             dpdk-devbind --status
 
-            apt install /vagrant/tmp/build/glb-director_*.deb
+            apt install /vagrant/tmp/build/glb-director_*.deb /vagrant/tmp/build/glb-director-cli_*.deb
             apt install /vagrant/tmp/build/glb-healthcheck_*.deb
 
             /vagrant/script/helpers/configure-vagrant-director.sh dpdk "#{ipv4_addr}"
@@ -142,7 +142,7 @@ Vagrant.configure("2") do |config|
         end
 
         if example_setup_type == 'xdp'
-          v.vm.provision "shell", run: "always", inline: <<-SHELL
+          v.vm.provision "Configure XDP example setup", type: "shell", run: "always", inline: <<-SHELL
             DEBIAN_FRONTEND=noninteractive apt install -y /vagrant/tmp/build/glb-director-xdp_*.deb /vagrant/tmp/build/glb-director-cli_*.deb /vagrant/tmp/build/xdp-root-shim_*.deb
             DEBIAN_FRONTEND=noninteractive apt install -y /vagrant/tmp/build/glb-healthcheck_*.deb
 
@@ -151,7 +151,7 @@ Vagrant.configure("2") do |config|
         end
       else
         # test setup
-        v.vm.provision "shell", run: "always", inline: <<-SHELL
+        v.vm.provision "Bring up the test interface", type: "shell", run: "always", inline: <<-SHELL
           ip addr add #{ipv6_addr} dev eth1 || true
         SHELL
       end
@@ -164,12 +164,12 @@ Vagrant.configure("2") do |config|
 
       v.vm.network "private_network", ip: ipv4_addr, virtualbox__intnet: "glb_datacenter_network"
 
-      v.vm.provision "shell", inline: <<-SHELL
+      v.vm.provision "Set up proxy nginx demo", type: "shell", inline: <<-SHELL
         DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
         echo "hello world from #{name} via GLB" >/var/www/html/index.html
       SHELL
 
-      v.vm.provision "shell", run: "always", inline: <<-SHELL
+      v.vm.provision "Configure tunnels on proxy", type: "shell", run: "always", inline: <<-SHELL
         modprobe fou
         modprobe sit
         ip link set up dev tunl0 || true

--- a/script/cibuild-prepare
+++ b/script/cibuild-prepare
@@ -11,6 +11,7 @@ GLB_REDIRECT_VERSION="$( source src/glb-redirect/dkms.conf; echo $PACKAGE_VERSIO
 
 begin_fold "Bringing up and syncing vagrant test environment"
 (
+  vagrant box update
   vagrant up
 
   script/helpers/prepare-vagrant director-test

--- a/script/test-glb-healthcheck
+++ b/script/test-glb-healthcheck
@@ -9,9 +9,10 @@ cd "$(dirname "$0")/.."
 
 begin_fold "Testing glb-healthcheck daemon"
 (
-  vagrant ssh director-test -- bash /dev/stdin <<'EOF'
+  vagrant ssh director-test -- sudo bash /dev/stdin <<'EOF'
+    . /etc/profile.d/gopath.sh
     cd /vagrant/src/glb-healthcheck
-    sudo script/test
+    script/test
 EOF
 )
 end_fold

--- a/src/glb-director/script/test
+++ b/src/glb-director/script/test
@@ -42,8 +42,8 @@ begin_fold "Building glb-director for testing"
   make clean
   make -C cli clean
 
-  scan-build make
-  scan-build make -C cli
+  scan-build-10 make
+  scan-build-10 make -C cli
 )
 end_fold
 

--- a/src/glb-director/tests/glb_test_utils.py
+++ b/src/glb-director/tests/glb_test_utils.py
@@ -58,8 +58,6 @@ class DirectorControlBase(object):
 		pass
 
 class DPDKDirectorControl(DirectorControlBase):
-	IFACE_NAME_KNI = 'vglb_kni0'
-
 	def __init__(self):
 		assert os.path.exists('/dev/kni'), "KNI kernel module not loaded"
 
@@ -82,10 +80,12 @@ class DPDKDirectorControl(DirectorControlBase):
 
 		print 'launched as pid', self.director.pid
 
+		ip = IPRoute()
+
 		# wait for the kni interface to come up, indicating the app is ready
 		try:
 			with timeout(10):
-				while len(ip.link_lookup(ifname=cls.IFACE_NAME_KNI)) == 0:
+				while len(ip.link_lookup(ifname=GLBDirectorTestBase.IFACE_NAME_KNI)) == 0:
 					time.sleep(0.1)
 		except TimeoutException:
 			self.director.kill()
@@ -95,7 +95,7 @@ class DPDKDirectorControl(DirectorControlBase):
 
 		# bring up the KNI interface
 		try:
-			idx = ip.link_lookup(ifname=cls.IFACE_NAME_KNI)[0]
+			idx = ip.link_lookup(ifname=GLBDirectorTestBase.IFACE_NAME_KNI)[0]
 			ip.link('set', index=idx, state='up')
 		except NetlinkError:
 			self.director.kill()
@@ -115,7 +115,7 @@ class DPDKDirectorControl(DirectorControlBase):
 			self.director.send_signal(signal.SIGUSR1)
 	
 	def kni(self):
-		return L2ListenSocket(iface=cls.IFACE_NAME_KNI, promisc=True)
+		return L2ListenSocket(iface=GLBDirectorTestBase.IFACE_NAME_KNI, promisc=True)
 
 class SystemdNotify(object):
 	def __init__(self, unix_path):
@@ -217,6 +217,7 @@ class GLBDirectorTestBase():
 
 	IFACE_NAME_PY = 'vglbtest_py'
 	IFACE_NAME_DIRECTOR = 'vglbtest_dpdk'
+	IFACE_NAME_KNI = 'vglb_kni0'
 
 	eth_tx = None
 	kni_tx = None


### PR DESCRIPTION
This PR gets a `script/cibuild` back to functional from a completely non-existant Vagrant setup (e.g. after `vagrant destroy -f`). It also adds some additional naming to vagrant provisioners to more easily diagnose which is failing.

Currently the Vagrant setup fails to come up cleanly, and then the tests inside regressed when the XDP director was introduced.