### PR TITLE
Pin fpm to a working version

### DIFF
--- a/script/Dockerfile.stretch
+++ b/script/Dockerfile.stretch
@@ -18,7 +18,8 @@ ENV PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
 
 # fpm for packaging
 RUN apt-get update && apt-get install -y ruby ruby-dev rubygems build-essential
-RUN gem install --no-ri --no-rdoc rake fpm
+# pin fpm 1.11.0 until https://github.com/jordansissel/fpm/pull/1752 is fixed
+RUN gem install --no-ri --no-rdoc rake fpm:1.11.0
 
 # patch DKMS for source package generation https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=832558
 ADD helpers/dkms.diff /root/dkms.diff


### PR DESCRIPTION
fpm 1.12 generates deb packages with a failing postinst script, as described in https://github.com/jordansissel/fpm/issues/1749. 

When I run `scripts/cibuild`, the setup fails for `glb-healthcheck` and `glb-director` packages.

After I pinned the fpm version like this PR does, `scripts/cibuild` completed successfully.