### PR TITLE
Add a timeout to http healthchecker connections

### DIFF
--- a/src/glb-healthcheck/HttpHealthChecker.go
+++ b/src/glb-healthcheck/HttpHealthChecker.go
@@ -52,12 +52,15 @@ type HttpHealthChecker struct {
 // that will be given a HealthResult once completed. the timeouts here are
 // from http.Get, the caller will handle the shorter check interval timeout
 // for simplicity.
-func httpCheckURL(url string) HealthResultStream {
+func httpCheckURL(url string, timeoutSec time.Duration) HealthResultStream {
 	ch := make(HealthResultStream, 1)
 
 	go func() {
 		httpCounters.Add("Checks", 1)
-		resp, err := http.Get(url)
+		var httpClient = &http.Client {
+			Timeout: timeoutSec,
+		}
+		resp, err := httpClient.Get(url)
 		if err != nil {
 			ch <- HealthResult{Healthy: false, Failure: err.Error()}
 			close(ch)
@@ -95,7 +98,7 @@ func (h *HttpHealthChecker) CheckTarget(resultChannel HealthResultStream, target
 
 	go func() {
 		logContext.Debug("Sending HTTP request to health check port")
-		resultCh := httpCheckURL(fmt.Sprintf("http://%s:%d%s", target.Ip, target.Port, target.Uri))
+		resultCh := httpCheckURL(fmt.Sprintf("http://%s:%d%s", target.Ip, target.Port, target.Uri), h.checkTimeout)
 
 		// either receive the successful result, or time out and craft an error result.
 		var result HealthResult


### PR DESCRIPTION
The healthchecker is the source of truth for the health status of the glb-proxy nodes to which traffic is directed from the director.
The healthchecker is configured to perform HTTP healthchecks on the glb-proxies via http.Get() of the configured URI. The connection setup for this http.Get() however does not configure a timeout. As a result, a bad proxy can, over time (a matter of minutes) cause a large number of open connections in the healthchecker leading to it hitting the MAX open files limit and subsequently failing connecting to any glb-proxy and thus marking every proxy as failed.

See related threads of discussion here:
https://github.slack.com/archives/CGNJD88A2/p1627908515043000
https://github.slack.com/archives/CGNJD88A2/p1627909019050400

/cc @shelson @awlx @theojulienne 