### PR TITLE
Fix float division result errors in Python 3

### DIFF
--- a/src/scapy-glb-gue/glb_scapy/glb_gue_scapy.py
+++ b/src/scapy-glb-gue/glb_scapy/glb_gue_scapy.py
@@ -36,7 +36,7 @@ class GLBGUE(Packet):
     name = "GLBGUE"
     fields_desc = [BitField("version", 0, 2),
                    BitField("control_msg", 0, 1),
-                   BitFieldLenField("hlen", None, 5, length_of='private_data', adjust=lambda pkt, x: (x / 4)),
+                   BitFieldLenField("hlen", None, 5, length_of='private_data', adjust=lambda pkt, x: (x // 4)),
                    BitField("protocol", 0, 8),
                    BitField("flags", 0, 16),
                    PacketListField("private_data", [], GLBGUEChainedRouting, length_from=lambda p:p.hlen * 4)


### PR DESCRIPTION
https://docs.python.org/3/howto/pyporting.html#division

Error without this change in Python 3 is:
```
/usr/lib/python3.9/site-packages/scapy/fields.py in addfield(self, pkt, s, ival)
   2167             v = 0
   2168         v <<= self.size
-> 2169         v |= val & ((1 << self.size) - 1)
   2170         bitsdone += self.size
   2171         while bitsdone >= 8:

TypeError: unsupported operand type(s) for &: 'float' and 'int'
```