### PR TITLE
Update python dependencies to newest possible versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-nose
-pyroute2
-scapy
-siphash
-netaddr
+nose==1.3.7
+pyroute2==0.5.19
+scapy==2.4.0
+siphash==0.0.1
+netaddr=0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-nose==1.3.7
-pyroute2==0.5.3
-scapy==2.4.0
-siphash==0.0.1
-netaddr==0.7.19
+nose
+pyroute2
+scapy
+siphash
+netaddr


### PR DESCRIPTION
Scapy broke back in #53 but the current version is 2.4.5 - and the issue was fixed in 2.4.3. To work this out I temporarily modified script/test to install a specific version of scapy before running the tests - and could see pretty quickly when it was fixed.

```
vagrant@director-test:/vagrant/src/glb-redirect$ sudo script/test 2.4.0 2>&1 | grep broadcast
vagrant@director-test:/vagrant/src/glb-redirect$ sudo script/test 2.4.1 2>&1 | grep broadcast
scapy.runtime: WARNING: Mac address to reach destination not found. Using broadcast.
scapy.runtime: WARNING: Mac address to reach destination not found. Using broadcast.
vagrant@director-test:/vagrant/src/glb-redirect$ sudo script/test 2.4.2 2>&1 | grep broadcast
scapy.runtime: WARNING: Mac address to reach destination not found. Using broadcast.
scapy.runtime: WARNING: Mac address to reach destination not found. Using broadcast.
vagrant@director-test:/vagrant/src/glb-redirect$ sudo script/test 2.4.3 2>&1 | grep broadcast
vagrant@director-test:/vagrant/src/glb-redirect$ sudo script/test 2.4.5 2>&1 | grep broadcast
vagrant@director-test:/vagrant/src/glb-redirect$
```