### PR TITLE
Actually pin scapy to 2.4.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nose==1.3.7
 pyroute2==0.5.19
-scapy==2.4.0
+scapy==2.4.5
 siphash==0.0.1
 netaddr=0.8.0


### PR DESCRIPTION
https://github.com/github/glb-director/pull/142 failed to set the correct version for scapy - this fixes that.