### PR TITLE
This adds compatibility for kernel >= 5.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Run package build focal
       run: script/cibuild-create-packages-focal
+    - name: Tar files
+      run: tar -cvf glb-director.tar $GITHUB_WORKSPACE/tmp/build
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: glb-director
+        path: glb-director.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Run package build stretch
-      run: script/cibuild-create-packages
     - name: Run package build focal
       run: script/cibuild-create-packages-focal

--- a/src/glb-redirect/Makefile
+++ b/src/glb-redirect/Makefile
@@ -28,7 +28,7 @@ install: lib kmod
 	install ipt_GLBREDIRECT.ko $(DESTDIR)/lib/modules/$(shell uname -r)/updates
 
 KSRC=/usr/src/linux-headers-$(shell uname -r)
-IPT_CFLAGS=-I$(KSRC)/include/uapi -I$(KSRC)/include -DPIC -fPIC -Wno-cpp
+IPT_CFLAGS=-DPIC -fPIC -Wno-cpp
 IPT_LDFLAGS=-lxtables -shared
 
 %.so: %.c

--- a/src/glb-redirect/ipt_GLBREDIRECT.c
+++ b/src/glb-redirect/ipt_GLBREDIRECT.c
@@ -786,6 +786,18 @@ static int proc_open(struct inode *inode, struct file *file)
 	return single_open(file, proc_show, NULL);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
+#define HAVE_PROC_OPS
+#endif
+
+#ifdef HAVE_PROC_OPS
+static const struct proc_ops proc_operations = {
+  .proc_open = proc_open,
+  .proc_read = seq_read,
+  .proc_lseek = seq_lseek,
+  .proc_release = single_release,
+};
+#else
 static const struct file_operations proc_operations = {
 	.owner		= THIS_MODULE,
 	.open		= proc_open,
@@ -793,6 +805,7 @@ static const struct file_operations proc_operations = {
 	.llseek		= seq_lseek,
 	.release	= single_release,
 };
+#endif
 
 static int __init glbredirect_tg4_init(void)
 {

--- a/src/glb-redirect/ipt_GLBREDIRECT.c
+++ b/src/glb-redirect/ipt_GLBREDIRECT.c
@@ -792,10 +792,10 @@ static int proc_open(struct inode *inode, struct file *file)
 
 #ifdef HAVE_PROC_OPS
 static const struct proc_ops proc_operations = {
-  .proc_open = proc_open,
-  .proc_read = seq_read,
-  .proc_lseek = seq_lseek,
-  .proc_release = single_release,
+	.proc_open = proc_open,
+	.proc_read = seq_read,
+	.proc_lseek = seq_lseek,
+	.proc_release = single_release,
 };
 #else
 static const struct file_operations proc_operations = {


### PR DESCRIPTION
In kernels >= 5.6 `file_operations` was deprecated and replaced with `proc_ops`. This adds support for this.