### PR TITLE
Potential fix for code scanning alert no. 39: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: ci
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   package-build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/github/glb-director/security/code-scanning/39](https://github.com/github/glb-director/security/code-scanning/39)

To fix the problem, add a `permissions` block granting only the minimum required privileges to the GITHUB_TOKEN in this workflow. Since the workflow only checks out code, builds, tars files, and uploads artifacts, it only needs read access to repository content (`contents: read`). Place the `permissions` key at the top level of the workflow (above `jobs:`) so it will apply to all jobs in this workflow. No additional imports or code changes are required—just add the permissions block specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
