### PR TITLE
Upgrade scapy to v2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 nose==1.3.7
 pyroute2==0.5.19
-scapy==2.7.0
+scapy==2.7.0rc1
 siphash==0.0.1
 netaddr==0.8.0


### PR DESCRIPTION
Resolves: https://github.com/github/glb-director/security/dependabot/22

Upgrade the scapy library to 2.7.0. Fix a syntax error in the requirements file: 
```
pip._internal.exceptions.InstallationError: Invalid requirement: 'netaddr=0.8.0' (from line 5 of requirements.txt)
Hint: = is not a valid operator. Did you mean == ?
```