### PR TITLE
Exclude the patch number from go.mod

### DIFF
--- a/src/glb-healthcheck/go.mod
+++ b/src/glb-healthcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/glb-director/src/glb-healthcheck
 
-go 1.24.5
+go 1.24
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20160216232012-784ddc588536


### PR DESCRIPTION
https://go.dev/doc/modules/gomod-ref#go
The go directive in the go.mod file doesn't include the patch number.

```
go: errors parsing go.mod:
/tmp/brew2deb/packages/glb-director/tmp-build/glb-director.git/src/glb-healthcheck/go.mod:3: invalid go version '1.24.5': must match format 1.23
```