### PR TITLE
Add check for bad config and emit metric

### DIFF
--- a/src/glb-director-xdp/main.go
+++ b/src/glb-director-xdp/main.go
@@ -269,8 +269,27 @@ func (app *Application) SyncConfigMap() {
 	configMap.Put(unsafe.Pointer(&configKey), unsafe.Pointer(&hashFields))
 }
 
+// ValidateForwardingTableConfig checks that the forwarding table file can be
+// loaded and passes validation. Returns nil on success or an error describing
+// the failure. This is used to pre-validate before exec'ing a new process.
+func ValidateForwardingTableConfig(path string) error {
+	fwdConfig := C.create_glb_fwd_config(C.CString(path))
+	if fwdConfig == nil {
+		return fmt.Errorf("forwarding table validation failed for %s", path)
+	}
+	C.glb_fwd_config_ctx_decref(fwdConfig)
+	return nil
+}
+
 func (app *Application) ReloadForwardingTable() {
 	fwdConfig := C.create_glb_fwd_config(C.CString(app.ForwardingTablePath))
+	if fwdConfig == nil {
+		if app.StatsClient != nil {
+			app.StatsClient.Incr("config.reload_failure", []string{"reason:invalid_config"}, 1)
+			app.StatsClient.Flush()
+		}
+		log.Fatalf("Failed to load forwarding table from %s: config validation failed (0 tables, backends, or binds)", app.ForwardingTablePath)
+	}
 	defer C.glb_fwd_config_ctx_decref(fwdConfig)
 
 	tableMap4 := app.Collection.Maps["glb_binds"]
@@ -454,8 +473,18 @@ func (app *Application) runStatsCollection(globalCounters *ebpf.Map) {
 	}
 }
 
-func gracefullReloadByExec() {
+func (app *Application) gracefullReloadByExec() {
 	fmt.Printf("Reloading by exec-ing a new version of glb-director-xdp\n")
+
+	// Pre-validate the forwarding table before exec'ing. If the config is
+	// invalid, reject the reload and keep serving with the current config.
+	if err := ValidateForwardingTableConfig(app.ForwardingTablePath); err != nil {
+		log.Printf("gracefullReloadByExec: %v. Rejecting reload, continuing with current config.", err)
+		if app.StatsClient != nil {
+			app.StatsClient.Incr("config.reload_rejected", []string{"reason:invalid_config"}, 1)
+		}
+		return
+	}
 
 	// give us a temp working dir for socket comm
 	tmpDir, err := ioutil.TempDir("/tmp", "glb-xdp")
@@ -490,6 +519,9 @@ func gracefullReloadByExec() {
 	err = cmd.Start()
 	if err != nil {
 		log.Printf("gracefullReloadByExec: Failed to launch, error: %v", err)
+		if app.StatsClient != nil {
+			app.StatsClient.Incr("config.reload_rejected", []string{"reason:launch_failed"}, 1)
+		}
 		return
 	}
 
@@ -517,9 +549,15 @@ func gracefullReloadByExec() {
 			os.Exit(0)
 		} else {
 			log.Printf("gracefullReloadByExec: Expected READY=1, but got '%v', so assuming failure. Not reloading.", readyResponse)
+			if app.StatsClient != nil {
+				app.StatsClient.Incr("config.reload_rejected", []string{"reason:new_process_failed"}, 1)
+			}
 		}
 	case <-time.After(30 * time.Second):
 		log.Printf("gracefullReloadByExec: Expected READY=1 from new process, but timed out after 30 seconds. Not reloading.")
+		if app.StatsClient != nil {
+			app.StatsClient.Incr("config.reload_rejected", []string{"reason:timeout"}, 1)
+		}
 	}
 }
 
@@ -651,7 +689,7 @@ func main() {
 		sig := <-sigs
 
 		if sig == syscall.SIGUSR1 {
-			gracefullReloadByExec()
+			app.gracefullReloadByExec()
 		} else {
 			break
 		}

--- a/src/glb-director-xdp/main_test.go
+++ b/src/glb-director-xdp/main_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// cliPath returns the path to the glb-director-cli binary.
+// Tests expect it to be pre-built (e.g. via `make -C ../glb-director/cli`).
+func cliPath() string {
+	return filepath.Join("..", "glb-director", "cli", "glb-director-cli")
+}
+
+// buildForwardingTable generates a binary forwarding table from a JSON config
+// using glb-director-cli. Returns the path to the binary file.
+func buildForwardingTable(t *testing.T, config interface{}) string {
+	t.Helper()
+
+	jsonFile, err := ioutil.TempFile("", "glb-test-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp json file: %v", err)
+	}
+	defer os.Remove(jsonFile.Name())
+
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("failed to marshal config: %v", err)
+	}
+
+	if _, err := jsonFile.Write(data); err != nil {
+		t.Fatalf("failed to write json: %v", err)
+	}
+	jsonFile.Close()
+
+	binFile, err := ioutil.TempFile("", "glb-test-*.bin")
+	if err != nil {
+		t.Fatalf("failed to create temp bin file: %v", err)
+	}
+	binFile.Close()
+
+	cmd := exec.Command(cliPath(), "build-config", jsonFile.Name(), binFile.Name())
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("glb-director-cli build-config failed: %v\noutput: %s", err, output)
+	}
+
+	return binFile.Name()
+}
+
+// validTableConfig returns a minimal valid forwarding table JSON config.
+func validTableConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"tables": []interface{}{
+			map[string]interface{}{
+				"hash_key": "12345678901234561234567890123456",
+				"seed":     "34567890123456783456789012345678",
+				"binds": []interface{}{
+					map[string]interface{}{"ip": "1.1.1.1", "proto": "tcp", "port": 80},
+				},
+				"backends": []interface{}{
+					map[string]interface{}{"ip": "1.2.3.4", "state": "active", "healthy": true},
+					map[string]interface{}{"ip": "2.3.4.5", "state": "active", "healthy": true},
+				},
+			},
+		},
+	}
+}
+
+func TestValidateForwardingTableConfig_ValidConfig(t *testing.T) {
+	binPath := buildForwardingTable(t, validTableConfig())
+	defer os.Remove(binPath)
+
+	err := ValidateForwardingTableConfig(binPath)
+	if err != nil {
+		t.Errorf("expected valid config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateForwardingTableConfig_NonexistentFile(t *testing.T) {
+	err := ValidateForwardingTableConfig("/tmp/nonexistent-glb-test-file.bin")
+	if err == nil {
+		t.Error("expected error for nonexistent file, got nil")
+	}
+}
+
+func TestValidateForwardingTableConfig_EmptyFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "glb-test-empty-*.bin")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	f.Close()
+	defer os.Remove(f.Name())
+
+	err = ValidateForwardingTableConfig(f.Name())
+	if err == nil {
+		t.Error("expected error for empty file, got nil")
+	}
+}
+
+func TestValidateForwardingTableConfig_CorruptFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "glb-test-corrupt-*.bin")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	// Write garbage data
+	f.Write([]byte("this is not a valid forwarding table"))
+	f.Close()
+	defer os.Remove(f.Name())
+
+	err = ValidateForwardingTableConfig(f.Name())
+	if err == nil {
+		t.Error("expected error for corrupt file, got nil")
+	}
+}
+
+func TestValidateForwardingTableConfig_TruncatedFile(t *testing.T) {
+	// Build a valid config first, then truncate it
+	binPath := buildForwardingTable(t, validTableConfig())
+	defer os.Remove(binPath)
+
+	// Read the file and write only half of it back
+	data, err := ioutil.ReadFile(binPath)
+	if err != nil {
+		t.Fatalf("failed to read bin file: %v", err)
+	}
+
+	truncFile, err := ioutil.TempFile("", "glb-test-trunc-*.bin")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	truncFile.Write(data[:len(data)/2])
+	truncFile.Close()
+	defer os.Remove(truncFile.Name())
+
+	err = ValidateForwardingTableConfig(truncFile.Name())
+	if err == nil {
+		t.Error("expected error for truncated file, got nil")
+	}
+}
+
+func TestValidateForwardingTableConfig_MultiTableValid(t *testing.T) {
+	config := map[string]interface{}{
+		"tables": []interface{}{
+			map[string]interface{}{
+				"hash_key": "12345678901234561234567890123456",
+				"seed":     "34567890123456783456789012345678",
+				"binds": []interface{}{
+					map[string]interface{}{"ip": "1.1.1.1", "proto": "tcp", "port": 80},
+				},
+				"backends": []interface{}{
+					map[string]interface{}{"ip": "1.2.3.4", "state": "active", "healthy": true},
+					map[string]interface{}{"ip": "2.3.4.5", "state": "active", "healthy": true},
+				},
+			},
+			map[string]interface{}{
+				"hash_key": "12345678901234561234567890123456",
+				"seed":     "12345678901234561234567890123456",
+				"binds": []interface{}{
+					map[string]interface{}{"ip": "1.1.1.2", "proto": "tcp", "port": 443},
+				},
+				"backends": []interface{}{
+					map[string]interface{}{"ip": "4.5.6.7", "state": "active", "healthy": true},
+					map[string]interface{}{"ip": "5.6.7.8", "state": "active", "healthy": true},
+					map[string]interface{}{"ip": "6.7.8.9", "state": "active", "healthy": true},
+				},
+			},
+		},
+	}
+
+	binPath := buildForwardingTable(t, config)
+	defer os.Remove(binPath)
+
+	err := ValidateForwardingTableConfig(binPath)
+	if err != nil {
+		t.Errorf("expected valid multi-table config to pass validation, got error: %v", err)
+	}
+}

--- a/src/glb-director/glb_fwd_config.c
+++ b/src/glb-director/glb_fwd_config.c
@@ -82,7 +82,6 @@ struct glb_fwd_config_ctx *create_glb_fwd_config(const char *config_file)
 		    "glb-config loading failed: could not allocate context "
 		    "struct");
 		munmap(source_data, fs.st_size);
-		goto cleanup;
 		goto fail;
 	}
 
@@ -100,7 +99,6 @@ struct glb_fwd_config_ctx *create_glb_fwd_config(const char *config_file)
 		    "copy");
 		munmap(source_data, fs.st_size);
 		goto cleanup;
-		goto fail;
 	}
 
 	memcpy(ctx->raw_config, source_data, ctx->raw_config_size);
@@ -112,7 +110,6 @@ struct glb_fwd_config_ctx *create_glb_fwd_config(const char *config_file)
 	config_status = check_config(ctx);
 	if (config_status != 0) {
 		goto cleanup;
-		goto fail;
 	}
 
 #ifndef NO_DPDK
@@ -129,7 +126,6 @@ struct glb_fwd_config_ctx *create_glb_fwd_config(const char *config_file)
 		    "glb-config loading failed: could not create a bind "
 		    "classifier");
 		goto cleanup;
-		goto fail;
 	}
 #endif
 
@@ -140,7 +136,7 @@ cleanup:
 
 fail:
 	close(fd);
-	exit(1);
+	return NULL;
 
 }
 


### PR DESCRIPTION
This pull request addresses a race condition that can happen when the `glb-director-xdp` reads from an incomplete or unexpected config. 

The changes proposed are to check the config, emit a metric, and then safely reject the reload. This results in the old process left standing.

/cc @pavantc 