### PR TITLE
Fix install time error of glb-redirect on ubuntu noble

### DIFF
--- a/src/glb-redirect/Makefile
+++ b/src/glb-redirect/Makefile
@@ -7,6 +7,26 @@ DKMS_MOD_VER:=$(shell grep 'PACKAGE_VERSION' dkms.conf | cut -d'=' -f2)
 
 obj-m += ipt_GLBREDIRECT.o
 
+# Probe the kernel headers for the __cookie_v[46]_check() arity. Upstream
+# removed the trailing 'cookie' argument in Linux 6.8, but distributions
+# backport the change, so a LINUX_VERSION_CODE check in the C code is not
+# reliable on its own. When we can read net/tcp.h we pass a definitive answer
+# through to the C code; otherwise it falls back to a version heuristic. The
+# 3-arg declaration carries a trailing 'u32 cookie' parameter (the only u32 in
+# the prototype), so its presence distinguishes the two forms.
+COOKIE_TCP_H := $(firstword $(wildcard $(srctree)/include/net/tcp.h $(srctree)/source/include/net/tcp.h))
+ifneq ($(COOKIE_TCP_H),)
+# Capture the probe result in a plain variable first: embedding the awk command
+# (which contains commas and parentheses) directly inside ifeq(...) would break
+# make's conditional parser.
+COOKIE_U32_COUNT := $(shell awk '/__cookie_v4_check/{f=1} f{b=b $$0} f&&/;/{print b; exit}' $(COOKIE_TCP_H) | grep -c 'u32')
+ifeq ($(COOKIE_U32_COUNT),0)
+ccflags-y += -DGLB_COOKIE_CHECK_NO_COOKIE_ARG
+else
+ccflags-y += -DGLB_COOKIE_CHECK_HAS_COOKIE_ARG
+endif
+endif
+
 all: lib kmod
 
 kmod:

--- a/src/glb-redirect/ipt_GLBREDIRECT.c
+++ b/src/glb-redirect/ipt_GLBREDIRECT.c
@@ -611,7 +611,13 @@ static unsigned int is_valid_locally(struct net *net, struct sk_buff *skb, int i
 			    	                !tcp_synq_no_recent_overflow(listen_sk));
 
 				if (want_cookie) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
+					/* The cookie/mss argument was removed; the kernel now
+					 * derives it from th->ack_seq internally. */
+					int mss = __cookie_v4_check(iph_v4, th);
+#else
 					int mss = __cookie_v4_check(iph_v4, th, ntohl(th->ack_seq) - 1);
+#endif
 					if (mss > 0)
 						ret = 1;
 				}
@@ -651,7 +657,13 @@ static unsigned int is_valid_locally(struct net *net, struct sk_buff *skb, int i
 			    	                !tcp_synq_no_recent_overflow(listen_sk));
 
 				if (want_cookie) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
+					/* The cookie/mss argument was removed; the kernel now
+					 * derives it from th->ack_seq internally. */
+					int mss = __cookie_v6_check(iph_v6, th);
+#else
 					int mss = __cookie_v6_check(iph_v6, th, ntohl(th->ack_seq) - 1);
+#endif
 					if (mss > 0)
 						ret = 1;
 				}

--- a/src/glb-redirect/ipt_GLBREDIRECT.c
+++ b/src/glb-redirect/ipt_GLBREDIRECT.c
@@ -87,6 +87,32 @@ struct glbgue_stats {
 #	error glb-redirect requires at least v4.4
 #endif
 
+/*
+ * __cookie_v[46]_check() lost their trailing 'cookie' argument upstream in
+ * Linux 6.8. Some distributions backport that change into earlier kernels
+ * (e.g. 6.6/6.7), so a LINUX_VERSION_CODE check alone is unreliable. The
+ * Makefile probes the kernel headers for the actual arity and defines one of
+ * the macros below; if it could not probe the header, we fall back to the
+ * mainline version boundary.
+ */
+#if !defined(GLB_COOKIE_CHECK_HAS_COOKIE_ARG) && !defined(GLB_COOKIE_CHECK_NO_COOKIE_ARG)
+#	if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
+#		define GLB_COOKIE_CHECK_NO_COOKIE_ARG
+#	else
+#		define GLB_COOKIE_CHECK_HAS_COOKIE_ARG
+#	endif
+#endif
+
+#ifdef GLB_COOKIE_CHECK_HAS_COOKIE_ARG
+#	define GLB_COOKIE_V4_CHECK(iph, th) __cookie_v4_check((iph), (th), ntohl((th)->ack_seq) - 1)
+#	define GLB_COOKIE_V6_CHECK(iph, th) __cookie_v6_check((iph), (th), ntohl((th)->ack_seq) - 1)
+#else
+	/* The cookie/mss argument was removed; the kernel derives it from
+	 * th->ack_seq internally. */
+#	define GLB_COOKIE_V4_CHECK(iph, th) __cookie_v4_check((iph), (th))
+#	define GLB_COOKIE_V6_CHECK(iph, th) __cookie_v6_check((iph), (th))
+#endif
+
 struct glbgue_stats __percpu *percpu_stats;
 
 static unsigned int is_valid_locally(struct net *net, struct sk_buff *skb, int inner_ip_ofs, struct iphdr *iph_v4, struct ipv6hdr *iph_v6, struct tcphdr *th);
@@ -611,13 +637,7 @@ static unsigned int is_valid_locally(struct net *net, struct sk_buff *skb, int i
 			    	                !tcp_synq_no_recent_overflow(listen_sk));
 
 				if (want_cookie) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
-					/* The cookie/mss argument was removed; the kernel now
-					 * derives it from th->ack_seq internally. */
-					int mss = __cookie_v4_check(iph_v4, th);
-#else
-					int mss = __cookie_v4_check(iph_v4, th, ntohl(th->ack_seq) - 1);
-#endif
+					int mss = GLB_COOKIE_V4_CHECK(iph_v4, th);
 					if (mss > 0)
 						ret = 1;
 				}
@@ -657,13 +677,7 @@ static unsigned int is_valid_locally(struct net *net, struct sk_buff *skb, int i
 			    	                !tcp_synq_no_recent_overflow(listen_sk));
 
 				if (want_cookie) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0)
-					/* The cookie/mss argument was removed; the kernel now
-					 * derives it from th->ack_seq internally. */
-					int mss = __cookie_v6_check(iph_v6, th);
-#else
-					int mss = __cookie_v6_check(iph_v6, th, ntohl(th->ack_seq) - 1);
-#endif
+					int mss = GLB_COOKIE_V6_CHECK(iph_v6, th);
 					if (mss > 0)
 						ret = 1;
 				}

--- a/src/glb-redirect/libxt_GLBREDIRECT.c
+++ b/src/glb-redirect/libxt_GLBREDIRECT.c
@@ -74,7 +74,12 @@ static struct xtables_target glbredirect_tg_reg = {
 	.x6_options    = GLBREDIRECT_opts,
 };
 
-void _init(void)
+/*
+ * Use a constructor function instead of the legacy `_init` symbol, which
+ * collides with crti.o's `_init` on newer toolchains (gcc-13/binutils on
+ * noble). libxtables runs the constructor on dlopen, same as before.
+ */
+static void __attribute__((constructor)) glbredirect_tg_init(void)
 {
 	xtables_register_target(&glbredirect_tg_reg);
 }

--- a/src/glb-redirect/script/test
+++ b/src/glb-redirect/script/test
@@ -22,4 +22,69 @@ set -e
 HOSTPATH=$(cd $(dirname "$0") && cd .. && pwd)
 cd "$(dirname "$0")/.."
 
+# ---------------------------------------------------------------------------
+# Compile-check the kernel module and userspace xtables target.
+#
+# The glb-redirect package ships as a source-only DKMS deb, so ipt_GLBREDIRECT.ko
+# and libxt_GLBREDIRECT.so are normally only compiled at install time on a real
+# host. Building them here catches kernel-API / toolchain regressions (e.g. the
+# __cookie_v[46]_check() arity change on 6.x kernels, or `_init` colliding with
+# crti.o's `_init` on newer binutils) -- the scapy tests below need the Vagrant
+# proxy network and are skipped otherwise.
+# ---------------------------------------------------------------------------
+compile_check() {
+  local kdir generic kasan kcsan
+
+  # Resolve kernel headers. Prefer the distro's *-generic headers -- that's what
+  # DKMS builds against on a real host, and it's the meaningful target here
+  # (noble GA = 6.8, focal = 5.x). In the glb-director build image,
+  # /usr/src/linux-headers-$(uname -r) is only a symlink to those generic
+  # headers carrying a misleading 'linuxkit' name (the Docker Desktop VM
+  # kernel), so resolve the real generic dir directly for clear, correct output.
+  # Fall back to the running kernel's headers on hosts running a non-generic
+  # flavour (e.g. -aws / -azure).
+  generic="$(ls -d /usr/src/linux-headers-*-generic 2>/dev/null | sort -V | tail -1 || true)"
+  if [ -n "$generic" ] && [ -d "$generic" ]; then
+    kdir="$generic"
+  elif [ -d "/usr/src/linux-headers-$(uname -r)" ]; then
+    kdir="/usr/src/linux-headers-$(uname -r)"
+  else
+    kdir=""
+  fi
+
+  # Skip gracefully where the build toolchain isn't available (e.g. the Vagrant
+  # director-test client VM, which only runs the scapy tests below).
+  if [ -z "$kdir" ] || [ ! -d "$kdir" ] || \
+     ! command -v cc >/dev/null 2>&1 || \
+     ! command -v make >/dev/null 2>&1 || \
+     ! pkg-config --exists xtables 2>/dev/null; then
+    echo "compile-check: build toolchain or kernel headers unavailable; skipping module compile." >&2
+    return 0
+  fi
+
+  # The glb-director build image globally patches these in-tree kernel headers
+  # for its BPF/clang XDP build (injecting <stdbool.h>/<stddef.h>), which breaks
+  # a normal gcc kernel-module compile. Strip the injected lines if present;
+  # this is a no-op on pristine headers (real hosts / Vagrant test VM).
+  kasan="$kdir/include/linux/kasan-checks.h"
+  kcsan="$kdir/include/linux/kcsan-checks.h"
+  if [ -w "$kasan" ]; then
+    sed -i '1,3{/^#define __USE_C99_MATH$/d; /^#include <stdbool.h>$/d}' "$kasan"
+  fi
+  if [ -w "$kcsan" ]; then
+    sed -i '1,3{/^#include <stddef.h>$/d}' "$kcsan"
+  fi
+
+  echo "compile-check: building glb-redirect (lib + kmod) against ${kdir}"
+  make KDIR="$kdir" clean lib kmod
+  test -f libxt_GLBREDIRECT.so
+  test -f ipt_GLBREDIRECT.ko
+  echo "compile-check: ok (libxt_GLBREDIRECT.so + ipt_GLBREDIRECT.ko built)"
+
+  # Tidy up build artifacts so they don't linger in the source tree.
+  make KDIR="$kdir" clean >/dev/null 2>&1 || true
+}
+
+compile_check
+
 PYTHONPATH=$(pwd)/../scapy-glb-gue/:$PYTHONPATH pytest -v tests/

--- a/src/glb-redirect/script/test
+++ b/src/glb-redirect/script/test
@@ -33,7 +33,7 @@ cd "$(dirname "$0")/.."
 # proxy network and are skipped otherwise.
 # ---------------------------------------------------------------------------
 compile_check() {
-  local kdir generic kasan kcsan
+  local kdir generic kasan kcsan backup_dir rc
 
   # Resolve kernel headers. Prefer the distro's *-generic headers -- that's what
   # DKMS builds against on a real host, and it's the meaningful target here
@@ -64,25 +64,50 @@ compile_check() {
 
   # The glb-director build image globally patches these in-tree kernel headers
   # for its BPF/clang XDP build (injecting <stdbool.h>/<stddef.h>), which breaks
-  # a normal gcc kernel-module compile. Strip the injected lines if present;
-  # this is a no-op on pristine headers (real hosts / Vagrant test VM).
+  # a normal gcc kernel-module compile. We strip the injected lines for the
+  # duration of the compile only -- backing the originals up first and restoring
+  # them on ANY exit (success, failure, or signal) so the test suite is
+  # non-destructive. This matters when running `sudo script/test` on a real host
+  # or Vagrant VM, where these headers are shared, writable, and relied upon by
+  # other builds. Stripping is a no-op on pristine headers.
   kasan="$kdir/include/linux/kasan-checks.h"
   kcsan="$kdir/include/linux/kcsan-checks.h"
+
+  backup_dir="$(mktemp -d)"
+  restore_headers() {
+    [ -f "$backup_dir/kasan-checks.h" ] && cp -p "$backup_dir/kasan-checks.h" "$kasan"
+    [ -f "$backup_dir/kcsan-checks.h" ] && cp -p "$backup_dir/kcsan-checks.h" "$kcsan"
+    rm -rf "$backup_dir"
+  }
+  trap 'restore_headers' EXIT
+
   if [ -w "$kasan" ]; then
+    cp -p "$kasan" "$backup_dir/kasan-checks.h"
     sed -i '1,3{/^#define __USE_C99_MATH$/d; /^#include <stdbool.h>$/d}' "$kasan"
   fi
   if [ -w "$kcsan" ]; then
+    cp -p "$kcsan" "$backup_dir/kcsan-checks.h"
     sed -i '1,3{/^#include <stddef.h>$/d}' "$kcsan"
   fi
 
   echo "compile-check: building glb-redirect (lib + kmod) against ${kdir}"
-  make KDIR="$kdir" clean lib kmod
-  test -f libxt_GLBREDIRECT.so
-  test -f ipt_GLBREDIRECT.ko
-  echo "compile-check: ok (libxt_GLBREDIRECT.so + ipt_GLBREDIRECT.ko built)"
+  rc=0
+  make KDIR="$kdir" clean lib kmod || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    test -f libxt_GLBREDIRECT.so && test -f ipt_GLBREDIRECT.ko || rc=1
+  fi
 
-  # Tidy up build artifacts so they don't linger in the source tree.
+  # Tidy up build artifacts, then restore the patched headers before returning
+  # so we never leave the host's kernel headers modified.
   make KDIR="$kdir" clean >/dev/null 2>&1 || true
+  restore_headers
+  trap - EXIT
+
+  if [ "$rc" -ne 0 ]; then
+    echo "compile-check: FAILED to build glb-redirect (lib + kmod)" >&2
+    return "$rc"
+  fi
+  echo "compile-check: ok (libxt_GLBREDIRECT.so + ipt_GLBREDIRECT.ko built)"
 }
 
 compile_check


### PR DESCRIPTION
The glb-redirect-iptables-dkms package failed to build on Ubuntu Noble (kernel 6.8+) because two things in the source are incompatible with newer kernels and toolchains.
1. The kernel module passed a third argument to __cookie_v[46]_check(), which dropped that argument in the 6.x kernel API.
2. The userspace xtables target defined a _init() function that collides with crti.o's _init on Noble's gcc-13/binutils. 



```
# Kernel module (DKMS build, kernel 6.8):
ipt_GLBREDIRECT.c: In function 'glbredirect_tg4':
ipt_GLBREDIRECT.c:614:51: error: too many arguments to function '__cookie_v4_check'
  614 |     int mss = __cookie_v4_check(iph_v4, th, ntohl(th->ack_seq) - 1);
      |                                                   ^~~~~~~~~~~~~
In file included from ipt_GLBREDIRECT.c:NN:
.../include/net/tcp.h:NNN:5: note: declared here
  NNN | int __cookie_v4_check(const struct iphdr *iph, const struct tcphdr *th);
      |     ^~~~~~~~~~~~~~~~~
ipt_GLBREDIRECT.c:654:51: error: too many arguments to function '__cookie_v6_check'
  654 |     int mss = __cookie_v6_check(iph_v6, th, ntohl(th->ack_seq) - 1);
      |                                                   ^~~~~~~~~~~~~

# Userspace xtables target (link stage, gcc-13/binutils on noble):
/usr/bin/ld: libxt_GLBREDIRECT.c:(.text+0xNN): multiple definition of `_init';
  /usr/lib/x86_64-linux-gnu/crti.o:(.init+0x0): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:35: libxt_GLBREDIRECT.so] Error 1
```

Because the package ships as a source-only DKMS deb, these errors only surfaced at install time and were never caught in CI. The fix version-guards the cookie calls and replaces _init() with a constructor function, plus adds a compile check to the test suite.